### PR TITLE
Localise content for questions

### DIFF
--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -66,7 +66,7 @@ module Applicants
     def age_less_than_maximum
       return unless date_of_birth.present? && (Date.current.year - date_of_birth.year) >= MAX_AGE
 
-      errors.add(:date_of_birth, "age should be below #{MAX_AGE} years")
+      errors.add(:date_of_birth)
     end
   end
 

--- a/app/views/applicants/application_routes/new.html.erb
+++ b/app/views/applicants/application_routes/new.html.erb
@@ -4,8 +4,8 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(:application_route,
-        legend: { text: "What is your employment status?", tag: "h1", size: "l" },
-          hint: { text: "Select one of the following options" },
+        legend: { text: t("applicants.application_routes.title"), tag: "h1", size: "l" },
+          hint: { text: t("applicants.application_routes.hint") },
       ) do %>
         <%= f.govuk_radio_button(
           :application_route,
@@ -15,8 +15,8 @@
         <%= f.govuk_radio_button(
               :application_route,
               :salaried_trainee,
-              label: { text: t("applicants.application_routes.radio_button.salaried_trainee") },
-              hint: { text: t("applicants.application_routes.hint.salaried_trainee") },
+              label: { text: t("applicants.application_routes.radio_button.salaried_trainee.text") },
+              hint: { text: t("applicants.application_routes.radio_button.salaried_trainee.hint") },
               link_errors: true,
             )%>
         <%= f.govuk_radio_button(

--- a/app/views/applicants/contract_details/new.html.erb
+++ b/app/views/applicants/contract_details/new.html.erb
@@ -5,13 +5,13 @@
 
       <%= f.govuk_radio_buttons_fieldset(
         :one_year,
-        legend: { text: "Are you employed on a contract lasting at least one year?", tag: "h1", size: "l" },
-        hint: {text: "Your contract can also be ongoing or permanent." }) do %>
+        legend: { text: t("applicants.contract_details.title"), tag: "h1", size: "l" },
+        hint: {text: t("applicants.contract_details.hint") }) do %>
         <% Applicants::ContractDetail::ONE_YEAR_OPTIONS.each_with_index do |value, i| %>
           <%= f.govuk_radio_button :one_year, value, label: { text: value.humanize }, link_errors: i.zero? %>
         <% end %>
       <% end %>
-      
+
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/applicants/contract_start_dates/new.html.erb
+++ b/app/views/applicants/contract_start_dates/new.html.erb
@@ -4,7 +4,7 @@
 
       <%= f.govuk_error_summary %>
       
-      <%= f.govuk_date_field :contract_start_date, legend: { text: "Enter the start date of your contract", tag: "h1", size: "l" } %>
+      <%= f.govuk_date_field :contract_start_date, legend: { text: t("applicants.contract_start_dates.title"), tag: "h1", size: "l" } %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/applicants/employment_details/new.html.erb
+++ b/app/views/applicants/employment_details/new.html.erb
@@ -5,18 +5,18 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        Employment information
+        <%= t("applicants.employment_details.title") %>
       </h1>
 
-      <%= f.govuk_text_field :school_headteacher_name, label: { text: "Enter the name of the Headteacher or Principal of the school", size: "s" } %>
+      <%= f.govuk_text_field :school_headteacher_name, label: { text: t("applicants.employment_details.headteacher"), size: "s" } %>
 
       <%= f.govuk_text_field :school_name, label: { text: t("applicants.employment_details.school_name.title.#{application_route}"), size: "s" } %>
-      <%= f.govuk_fieldset legend: { text: 'Enter the school address', size: 's' } do %>
-        <%= f.govuk_text_field :school_address_line_1, label: { text: 'Address line 1', size: "s"} %>
-        <%= f.govuk_text_field :school_address_line_2, label: { text: 'Address line 2 (Optional)', size: "s"} %>
-        <%= f.govuk_text_field :school_city, label: { text: 'Town or city', size: "s"} %>
-        <%= f.govuk_text_field :school_county, label: { text: 'County (optional)', size: "s"} %>
-        <%= f.govuk_text_field :school_postcode, label: { text: 'Postcode', size: "s"} %>
+      <%= f.govuk_fieldset legend: { text: t("applicants.employment_details.address"), size: 's' } do %>
+        <%= f.govuk_text_field :school_address_line_1, label: { text: t("applicants.employment_details.address_line_1"), size: "s"} %>
+        <%= f.govuk_text_field :school_address_line_2, label: { text: t("applicants.employment_details.address_line_2"), size: "s"} %>
+        <%= f.govuk_text_field :school_city, label: { text: t("applicants.employment_details.city"), size: "s"} %>
+        <%= f.govuk_text_field :school_county, label: { text: t("applicants.employment_details.county"), size: "s"} %>
+        <%= f.govuk_text_field :school_postcode, label: { text: t("applicants.employment_details.postcode"), size: "s"} %>
       <% end %>
 
       <%= f.govuk_submit "Submit application" %>

--- a/app/views/applicants/personal_details/new.html.erb
+++ b/app/views/applicants/personal_details/new.html.erb
@@ -5,35 +5,35 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        Personal information
+        <%= t("applicants.personal_details.title") %>
       </h1>
 
-      <%= f.govuk_text_field :given_name, label: { text: "Enter your given name, as it appears on your passport", size: "s" } %>
-      <%= f.govuk_text_field :family_name, label: { text: "Enter your family name, as it appears on your passport", size: "s" } %>
-      <%= f.govuk_text_field :email_address, label: { text: "Enter your current email address", size: "s" }, hint: { text: "We will use this to contact you so please make sure you have entered it correctly." } %>
+      <%= f.govuk_text_field :given_name, label: { text: t("applicants.personal_details.given_name")  , size: "s" } %>
+      <%= f.govuk_text_field :family_name, label: { text: t("applicants.personal_details.family_name") , size: "s" } %>
+      <%= f.govuk_text_field :email_address, label: { text: t("applicants.personal_details.email_address") , size: "s" }, hint: { text: "We will use this to contact you so please make sure you have entered it correctly." } %>
       <%= f.govuk_text_field :phone_number,
-        label: { text: "Enter your current phone number", size: "s" },
-        hint: { text: "For international numbers include the country code. We will use this to contact you so please make sure you have entered it correctly." }
+        label: { text: t("applicants.personal_details.phone_number.title"), size: "s" },
+        hint: { text:  t("applicants.personal_details.phone_number.hint") }
       %>
-      <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: "Enter your date of birth, as it appears on your passport", size: "s" } %>
+      <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t("applicants.personal_details.date_of_birth"), size: "s" } %>
 
-      <%= f.govuk_fieldset legend: { text: 'Enter your address', size: 's' } do %>
-        <%= f.govuk_text_field :address_line_1, label: { text: 'Address line 1', size: "s"} %>
-        <%= f.govuk_text_field :address_line_2, label: { text: 'Address line 2 (Optional)', size: "s"} %>
-        <%= f.govuk_text_field :city, label: { text: 'Town or city', size: "s"} %>
-        <%= f.govuk_text_field :county, label: { text: 'County (optional)', size: "s"} %>
-        <%= f.govuk_text_field :postcode, label: { size: "s"} %>
+      <%= f.govuk_fieldset legend: { text: t("applicants.personal_details.address") , size: 's' } do %>
+        <%= f.govuk_text_field :address_line_1, label: { text: t("applicants.personal_details.address_line_1") , size: "s"} %>
+        <%= f.govuk_text_field :address_line_2, label: { text: t("applicants.personal_details.address_line_2") , size: "s"} %>
+        <%= f.govuk_text_field :city, label: { text: t("applicants.personal_details.city") , size: "s"} %>
+        <%= f.govuk_text_field :county, label: { text: t("applicants.personal_details.county") , size: "s"} %>
+        <%= f.govuk_text_field :postcode, label: { text: t("applicants.personal_details.postcode"), size: "s"} %>
       <% end %>
 
-      <%= f.govuk_select(:nationality, nationality_options, label: { text: "Nationality", size: "s" }) %>
+      <%= f.govuk_select(:nationality, nationality_options, label: { text: t("applicants.personal_details.nationality") , size: "s" }) %>
 
-      <%= f.govuk_radio_buttons_fieldset(:sex, legend: { text: "Select your sex", size: "s" }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:sex, legend: { text: t("applicants.personal_details.sex"), size: "s" }) do %>
         <% Applicants::PersonalDetail::SEX_OPTIONS.each_with_index do |value, i| %>
           <%= f.govuk_radio_button :sex, value, label: { text: value.humanize }, link_errors: i.zero? %>
         <% end %>
       <% end %>
 
-      <%= f.govuk_text_field :passport_number, label: { text: "Enter your passport number, as it appears on your passport", size: "s" } %>
+      <%= f.govuk_text_field :passport_number, label: { text: t("applicants.personal_details.passport") , size: "s" } %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/applicants/salaried_course_details/new.html.erb
+++ b/app/views/applicants/salaried_course_details/new.html.erb
@@ -6,8 +6,8 @@
 
       <%= f.govuk_radio_buttons_fieldset(
         :eligible_course,
-        hint: { text: "Check with your training provider if you're not sure. You will still be eligible for the international relocation payment if your course leads to PGCE + QTS or PGDE + QTS." },
-        legend: { text: "Are you currently employed in a school as a trainee teacher, on a teacher training course in England which meets the following conditions?", tag: "h1", size: "l" }
+        hint: { text: t("applicants.salaried_course.hint") },
+        legend: { text: t("applicants.salaried_course.title"), tag: "h1", size: "l" }
       ) do %>
 
         <p class="govuk-body">

--- a/app/views/applicants/school_details/new.html.erb
+++ b/app/views/applicants/school_details/new.html.erb
@@ -5,8 +5,8 @@
 
       <%= f.govuk_radio_buttons_fieldset(
         :state_funded_secondary_school,
-        legend: { text: "Are you employed by an English state secondary school?", tag: "h1", size: "l" },
-        hint: { text: "State schools receive funding from the UK government. Secondary schools teach children aged 11 to 16 or 18." }
+        legend: { text: t("applicants.school_details.title"), tag: "h1", size: "l" },
+        hint: { text: t("applicants.school_details.hint") }
         ) do %>
         <% Applicants::SchoolDetail::SCHOOL_OPTIONS.each_with_index do |value, i| %>
           <%= f.govuk_radio_button :state_funded_secondary_school, value, label: { text: value.humanize }, link_errors: i.zero? %>

--- a/app/views/applicants/visas/new.html.erb
+++ b/app/views/applicants/visas/new.html.erb
@@ -7,10 +7,10 @@
       <%= f.govuk_select(
         :visa_type,
         visa_options,
-        label: { text: "Select the visa you used to move to England", tag: "h1", size: "l" },
+        label: { text: t("applicants.visa.title"), tag: "h1", size: "l" },
         include_blank: true
         )%>
-  
+
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,6 +150,7 @@ en:
               invalid: Enter a telephone number, like 07700 900 982 or +34 626 587 210’
             date_of_birth:
               blank: Enter your date of birth
+              invalid: Age must be below 80
             sex:
               blank: Enter your sex
             passport_number:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,17 +51,6 @@ en:
     school_details:
       title: Are you employed by an English state secondary school?
       hint: State schools receive funding from the UK government. Secondary schools teach children aged 11 to 16 or 18.
-    subjects:
-      title:
-        teacher: What subject are you employed to teach at your school?
-        salaried_trainee: What subject are you training to teach?
-      hint:
-        teacher:
-          Physics, general or combined science including physics, and languages can be combined with other subjects but 
-          must make up at least 50% of your time in the classroom. This will be validated by DfE with your school.
-        salaried_trainee:
-          Physics or languages can be combined with other subjects but must make up at least 50% of your course content. 
-          This will be validated by DfE with your school.
     employment_details:
       title: Employment information
       school_name:
@@ -93,6 +82,17 @@ en:
       nationality: Nationality
       sex: Select your sex
       passport: Enter your passport number, as it appears on your passport
+    subjects:
+      title:
+        teacher: What subject are you employed to teach at your school?
+        salaried_trainee: What subject are you training to teach?
+      hint:
+        teacher:
+          Physics, general or combined science including physics, and languages can be combined with other subjects but 
+          must make up at least 50% of your time in the classroom. This will be validated by DfE with your school.
+        salaried_trainee:
+          Physics or languages can be combined with other subjects but must make up at least 50% of your course content. 
+          This will be validated by DfE with your school.
     salaried_course:
       title: Are you currently employed in a school as a trainee teacher, on a teacher training course in England which meets the following conditions?
       hint: Check with your training provider if you're not sure. You will still be eligible for the international relocation payment if your course leads to PGCE + QTS or PGDE + QTS.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,10 +54,10 @@ en:
         teacher: What subject are you employed to teach at your school?
         salaried_trainee: What subject are you training to teach?
       hint:
-        teacher: >
+        teacher:
           Physics, general or combined science including physics, and languages can be combined with other subjects but 
           must make up at least 50% of your time in the classroom. This will be validated by DfE with your school.
-        salaried_trainee: >
+        salaried_trainee:
           Physics or languages can be combined with other subjects but must make up at least 50% of your course content. 
           This will be validated by DfE with your school.
     employment_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,8 @@ en:
       hint:
         teacher: Check with your school if you're not sure
         salaried_trainee: Check with your training provider if you're not sure.
+    visa:
+      title: Select the visa you used to move to England
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,9 @@ en:
       title:
         teacher: Enter the date you moved to England to start your teaching job
         salaried_trainee: Enter the date you moved to England to start your teacher training course
+    school_details:
+      title: Are you employed by an English state secondary school?
+      hint: State schools receive funding from the UK government. Secondary schools teach children aged 11 to 16 or 18.
     subjects:
       title:
         teacher: What subject are you employed to teach at your school?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,24 @@ en:
         title:
           teacher: Enter the name of the school where you are employed as a teacher
           salaried_trainee: Enter the name of the school where you are employed as a trainee teacher
+    personal_details:
+      title: Personal information
+      given_name: Enter your given name, as it appears on your passport
+      family_name: Enter your family name, as it appears on your passport
+      email_address: Enter your current email address
+      phone_number:
+        title: Enter your current phone number
+        hint: For international numbers include the country code. We will use this to contact you so please make sure you have entered it correctly.
+      date_of_birth: Enter your date of birth, as it appears on your passport
+      address: Enter your address
+      address_line_1: Address line 1
+      address_line_2: Address line 2 (Optional)
+      city: Town or city
+      county: County (optional)
+      postcode: Postcode
+      nationality: Nationality
+      sex: Select your sex
+      passport: Enter your passport number, as it appears on your passport
     teaching_details:
       title:
         teacher: Do you teach this subject for at least 50% of your teaching timetable?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
     contract_details:
       title: Are you employed on a contract lasting at least one year?
       hint: Your contract can also be ongoing or permanent.
+    contract_start_dates:
+      title: Enter the start date of your contract
     entry_dates:
       title:
         teacher: Enter the date you moved to England to start your teaching job

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,10 +61,19 @@ en:
           Physics or languages can be combined with other subjects but must make up at least 50% of your course content. 
           This will be validated by DfE with your school.
     employment_details:
+      title: Employment information
       school_name:
         title:
           teacher: Enter the name of the school where you are employed as a teacher
           salaried_trainee: Enter the name of the school where you are employed as a trainee teacher
+      headteacher: Enter the name of the Headteacher or Principal of the school
+      address: Enter the school address
+      address_line_1: Address line 1
+      address_line_2: Address line 2 (Optional)
+      city: Town or city
+      county: County (optional)
+      postcode: Postcode
+
     personal_details:
       title: Personal information
       given_name: Enter your given name, as it appears on your passport

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,7 +73,6 @@ en:
       city: Town or city
       county: County (optional)
       postcode: Postcode
-
     personal_details:
       title: Personal information
       given_name: Enter your given name, as it appears on your passport
@@ -92,6 +91,9 @@ en:
       nationality: Nationality
       sex: Select your sex
       passport: Enter your passport number, as it appears on your passport
+    salaried_course:
+      title: Are you currently employed in a school as a trainee teacher, on a teacher training course in England which meets the following conditions?
+      hint: Check with your training provider if you're not sure. You will still be eligible for the international relocation payment if your course leads to PGCE + QTS or PGDE + QTS.
     teaching_details:
       title:
         teacher: Do you teach this subject for at least 50% of your teaching timetable?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,11 +32,13 @@
 en:
   applicants:
     application_routes:
+      title: What is your employment status?
+      hint: Select one of the following options
       radio_button:
         teacher: I am employed as a teacher in a school in England
-        salaried_trainee: I am enrolled on a salaried teacher training course in England.
-      hint:
-        salaried_trainee: ‘Salaried’ means a course where you are paid a wage to work while you train.
+        salaried_trainee:
+          text: I am enrolled on a salaried teacher training course in England.
+          hint: ‘Salaried’ means a course where you are paid a wage to work while you train.
     contract_details:
       title: Are you employed on a contract lasting at least one year?
       hint: Your contract can also be ongoing or permanent.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,9 @@ en:
         salaried_trainee: I am enrolled on a salaried teacher training course in England.
       hint:
         salaried_trainee: ‘Salaried’ means a course where you are paid a wage to work while you train.
+    contract_details:
+      title: Are you employed on a contract lasting at least one year?
+      hint: Your contract can also be ongoing or permanent.
     entry_dates:
       title:
         teacher: Enter the date you moved to England to start your teaching job


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/eCID3QEs/92-localize-all-questions-so-they-are-easier-to-maintain

## Description

Adds localisation for questions (copy and options) and validation messages for all questions.
The goal is not translation, but to make it easier to maintain through time.
