### PR TITLE
Add entry date validation for trainee

### DIFF
--- a/app/controllers/applicants/entry_dates_controller.rb
+++ b/app/controllers/applicants/entry_dates_controller.rb
@@ -11,8 +11,6 @@ module Applicants
 
       if @entry_date.valid?
         if eligible?
-          session[:entry_date] = @entry_date.entry_date
-
           redirect_to(new_applicants_personal_detail_path)
         else
           redirect_to(ineligible_path)

--- a/app/controllers/applicants/entry_dates_controller.rb
+++ b/app/controllers/applicants/entry_dates_controller.rb
@@ -10,10 +10,7 @@ module Applicants
       @entry_date = EntryDate.new(entry_date_params)
 
       if @entry_date.valid?
-        if Policies::EntryDate.eligible?(
-          @entry_date.entry_date,
-          session[:contract_start_date],
-        )
+        if eligible?
           session[:entry_date] = @entry_date.entry_date
 
           redirect_to(new_applicants_personal_detail_path)
@@ -26,6 +23,13 @@ module Applicants
     end
 
   private
+
+    def eligible?
+      Policies::EntryDate.eligible?(
+        @entry_date.entry_date,
+        Date.parse(session[:contract_start_date]),
+      )
+    end
 
     def entry_date_params
       params.require(:applicants_entry_date).permit(

--- a/app/controllers/applicants/entry_dates_controller.rb
+++ b/app/controllers/applicants/entry_dates_controller.rb
@@ -10,7 +10,10 @@ module Applicants
       @entry_date = EntryDate.new(entry_date_params)
 
       if @entry_date.valid?
-        if @entry_date.eligible?(session)
+        if Policies::EntryDate.eligible?(
+          @entry_date.entry_date,
+          session[:contract_start_date],
+        )
           session[:entry_date] = @entry_date.entry_date
 
           redirect_to(new_applicants_personal_detail_path)

--- a/app/models/applicants/entry_date.rb
+++ b/app/models/applicants/entry_date.rb
@@ -18,11 +18,5 @@ module Applicants
     rescue StandardError
       InvalidDate.new(day:, month:, year:)
     end
-
-    # If the applicant is a teacher who entered the country more than three
-    # months before their contract start date, they are not eligible.
-    def eligible?(session)
-      entry_date >= Date.parse(session["contract_start_date"]) - 3.months
-    end
   end
 end

--- a/app/models/applicants/entry_date.rb
+++ b/app/models/applicants/entry_date.rb
@@ -22,8 +22,6 @@ module Applicants
     # If the applicant is a teacher who entered the country more than three
     # months before their contract start date, they are not eligible.
     def eligible?(session)
-      return true if session["application_route"] == "salaried_trainee"
-
       entry_date >= Date.parse(session["contract_start_date"]) - 3.months
     end
   end

--- a/app/models/policies/entry_date.rb
+++ b/app/models/policies/entry_date.rb
@@ -14,7 +14,7 @@
 #
 module Policies
   class EntryDate
-    def eligible?(entry_date, start_date)
+    def self.eligible?(entry_date, start_date)
       entry_date >= start_date - 3.months
     end
   end

--- a/app/models/policies/entry_date.rb
+++ b/app/models/policies/entry_date.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# The `EntryDate` class defines the policy for contract start dates.
+#
+# This Policy determines whether a given entry date is eligible based on the
+# start date of the contract. If the applicant entered the country 3 months
+# or less before the start of the contract, then they are eligible.
+#
+# @example
+#   Policies::ContractStartDate.eligible?(
+#     Date.new(2023, 1, 2),
+#     Date.new(2023, 4, 2)
+#   ) #=> true
+#
+module Policies
+  class EntryDate
+    def eligible?(entry_date, start_date)
+      entry_date >= start_date - 3.months
+    end
+  end
+end

--- a/spec/models/policies/entry_date_spec.rb
+++ b/spec/models/policies/entry_date_spec.rb
@@ -10,21 +10,21 @@ RSpec.describe Policies::EntryDate do
       entry_date = Date.parse("2020-01-03")
       start_date = Date.parse("2020-04-02")
 
-      expect(policy.new.eligible?(entry_date, start_date)).to be(true)
+      expect(policy.eligible?(entry_date, start_date)).to be(true)
     end
 
     it "returns true if the entry date is 3 months since start of contract" do
       entry_date = Date.parse("2020-01-02")
       start_date = Date.parse("2020-04-02")
 
-      expect(policy.new.eligible?(entry_date, start_date)).to be(true)
+      expect(policy.eligible?(entry_date, start_date)).to be(true)
     end
 
     it "returns false if the entry date is less than 3 months since start of contract" do
       entry_date = Date.parse("2020-01-01")
       start_date = Date.parse("2020-04-02")
 
-      expect(policy.new.eligible?(entry_date, start_date)).to be(false)
+      expect(policy.eligible?(entry_date, start_date)).to be(false)
     end
   end
 end

--- a/spec/models/policies/entry_date_spec.rb
+++ b/spec/models/policies/entry_date_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::EntryDate do
+  subject(:policy) { described_class }
+
+  describe "#eligible?" do
+    it "returns true if the entry date is more than 3 months since start of contract" do
+      entry_date = Date.parse("2020-01-03")
+      start_date = Date.parse("2020-04-02")
+
+      expect(policy.new.eligible?(entry_date, start_date)).to be(true)
+    end
+
+    it "returns true if the entry date is 3 months since start of contract" do
+      entry_date = Date.parse("2020-01-02")
+      start_date = Date.parse("2020-04-02")
+
+      expect(policy.new.eligible?(entry_date, start_date)).to be(true)
+    end
+
+    it "returns false if the entry date is less than 3 months since start of contract" do
+      entry_date = Date.parse("2020-01-01")
+      start_date = Date.parse("2020-04-02")
+
+      expect(policy.new.eligible?(entry_date, start_date)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/Fl92ae9o/75-trainee-route-start-of-contract-with-the-school
https://trello.com/c/Ny4xhpe6/58-trainee-route-users-date-of-entry-into-the-country

## Description

Following the work on #79, on this PR I am enabling the eligibility rule that prevents applicants
where the time between the `start_date` and the `entry_date` is above `3 months`.

I have extracted another Policy Object (`Policies::EntryDate`) in the same way I extracted the 
Contract Start Date in #51. 

