### PR TITLE
Update Urn algorithm: use only numbers and LT/TE prefix

### DIFF
--- a/app/controllers/applicants/personal_details_controller.rb
+++ b/app/controllers/applicants/personal_details_controller.rb
@@ -7,7 +7,11 @@ module Applicants
     end
 
     def create
-      @personal_detail = PersonalDetail.new(personal_detail_params)
+      @personal_detail = PersonalDetail.new(
+        personal_detail_params.merge(
+          application_route:,
+        ),
+      )
 
       if @personal_detail.valid?
         applicant = @personal_detail.save!

--- a/app/controllers/applicants/personal_details_controller.rb
+++ b/app/controllers/applicants/personal_details_controller.rb
@@ -7,11 +7,8 @@ module Applicants
     end
 
     def create
-      @personal_detail = PersonalDetail.new(
-        personal_detail_params.merge(
-          application_route:,
-        ),
-      )
+      @personal_detail = PersonalDetail.new(personal_detail_params)
+      @personal_detail.application_route = session["application_route"]
 
       if @personal_detail.valid?
         applicant = @personal_detail.save!

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -3,12 +3,13 @@
 module Applicants
   class PersonalDetail
     include ActiveModel::Model
-    attr_accessor :given_name, :family_name, :email_address, :phone_number,
+    attr_accessor :application_route, :given_name, :family_name, :email_address, :phone_number,
                   :day, :month, :year, :sex, :passport_number, :nationality, :address_line_1,
                   :address_line_2, :city, :county, :postcode
 
     SEX_OPTIONS = %w[female male].freeze
 
+    validates :application_route, presence: true
     validates :given_name, presence: true
     validates :family_name, presence: true
     validates :email_address, presence: true
@@ -37,6 +38,7 @@ module Applicants
 
     def save!
       Applicant.create!(
+        application_route: application_route,
         given_name: given_name,
         family_name: family_name,
         email_address: email_address,

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -16,14 +16,22 @@
 class Application < ApplicationRecord
   belongs_to :applicant
 
-  serialize :urn, Urn
-
   validates :application_date, presence: true
+
+  before_create :generate_urn
 
   def self.initialise_for_applicant!(applicant)
     create!(
       applicant: applicant,
       application_date: Date.current.to_s,
     )
+  end
+
+private
+
+  def generate_urn
+    route_type = applicant.application_route
+
+    self.urn = Urn.generate(route_type)
   end
 end

--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -7,7 +7,7 @@
 #
 # Example:
 #
-#   Urn.new.value # => "IRP 1A2B3C"
+#   Urn.new.value # => "IRP1A2B3C"
 #
 # As it implements `.dump` and `.load`, it can be used with `serialize` as
 # an Active Model. It can be included as an attribute in your model
@@ -26,8 +26,8 @@
 #   your_model.reload
 #   puts your_model.urn.value
 #
-#   Urn.dump(Urn.new) # => "IRP GA2B3C"
-#   Urn.load("IRP GA2B3C") # => #<Urn:0x00000001154a9a78 @value="IRP GA2B3C">
+#   Urn.dump(Urn.new) # => "IRPGA2B3C"
+#   Urn.load("IRPGA2B3C") # => #<Urn:0x00000001154a9a78 @value="IRPGA2B3C">
 #
 #  Duplications
 #    Total number of combinations is: 26^6 = 308,915,776 ~ 310M
@@ -58,7 +58,7 @@ class Urn
   private_constant :CHARSET, :PREFIX, :LENGTH
 
   def self.generate_urn
-    "#{PREFIX} " + Array.new(LENGTH) { CHARSET.sample }.join
+    PREFIX + Array.new(LENGTH) { CHARSET.sample }.join
   end
 
   private_methods :generate_urn

--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -7,49 +7,20 @@
 #
 # Example:
 #
-#   Urn.new.value # => "IRP1A2B3C"
-#
-# As it implements `.dump` and `.load`, it can be used with `serialize` as
-# an Active Model. It can be included as an attribute in your model
-# and automatically handle serialization/deserialization.
-#
-# Example with ActiveRecord:
-#   app/models/your_model.rb
-#
-#   class YourModel < ActiveRecord::Base
-#     serialize :urn, Urn
-#   end
-#
-#   your_model = YourModel.new
-#   your_model.urn = Urn.new
-#   your_model.save
-#   your_model.reload
-#   puts your_model.urn.value
-#
-#   Urn.dump(Urn.new) # => "IRPGA2B3C"
-#   Urn.load("IRPGA2B3C") # => #<Urn:0x00000001154a9a78 @value="IRPGA2B3C">
+#   Urn.generate('teacher')          # => "IRPTE1A2B3C"
+#   Urn.generate('teacher')          # => "IRPTE1A2B3C"
+#   Urn.generate('salaried_trainee') # => "IRPLT1A2B3C"
 #
 #  Duplications
 #    Total number of combinations is: 26^6 = 308,915,776 ~ 310M
+#
 class Urn
   attr_reader :value
+  attr_writer :suffix
 
-  def initialize(value = nil)
-    @value = value || Urn.generate_urn
-  end
-
-  def self.dump(urn)
-    urn.value
-  end
-
-  def self.load(value)
-    Urn.new(value)
-  end
-
-  def ==(other)
-    return false unless other.is_a?(Urn)
-
-    @value == other.value
+  def self.generate(applicant_type)
+    code = applicant_type_code(applicant_type)
+    PREFIX + code + Array.new(LENGTH) { CHARSET.sample }.join
   end
 
   CHARSET = %w[A B C D E F H J K L M N P R S T U V 2 3 4 5 6 7 8 9].freeze
@@ -57,9 +28,14 @@ class Urn
   LENGTH = 6
   private_constant :CHARSET, :PREFIX, :LENGTH
 
-  def self.generate_urn
-    PREFIX + Array.new(LENGTH) { CHARSET.sample }.join
+  def self.applicant_type_code(applicant_type)
+    case applicant_type
+    when "teacher"
+      "TE"
+    when "salaried_trainee"
+      "LT"
+    else
+      raise(ArgumentError, "Invalid applicant type: #{applicant_type}")
+    end
   end
-
-  private_methods :generate_urn
 end

--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -38,4 +38,5 @@ class Urn
       raise(ArgumentError, "Invalid applicant type: #{applicant_type}")
     end
   end
+  private_methods :applicant_type_code
 end

--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -7,12 +7,9 @@
 #
 # Example:
 #
-#   Urn.generate('teacher')          # => "IRPTE1A2B3C"
-#   Urn.generate('teacher')          # => "IRPTE1A2B3C"
-#   Urn.generate('salaried_trainee') # => "IRPLT1A2B3C"
-#
-#  Duplications
-#    Total number of combinations is: 26^6 = 308,915,776 ~ 310M
+#   Urn.generate('teacher')          # => "IRPTE123456"
+#   Urn.generate('teacher')          # => "IRPTE123456"
+#   Urn.generate('salaried_trainee') # => "IRPLT123456"
 #
 class Urn
   attr_reader :value
@@ -23,7 +20,7 @@ class Urn
     PREFIX + code + Array.new(LENGTH) { CHARSET.sample }.join
   end
 
-  CHARSET = %w[A B C D E F H J K L M N P R S T U V 2 3 4 5 6 7 8 9].freeze
+  CHARSET = %w[0 1 2 3 4 5 6 7 8 9].freeze
   PREFIX = "IRP"
   LENGTH = 6
   private_constant :CHARSET, :PREFIX, :LENGTH

--- a/app/views/applicants/submissions/show.html.erb
+++ b/app/views/applicants/submissions/show.html.erb
@@ -7,7 +7,7 @@
             Application complete
           </h1>
           <div class="govuk-panel__body">
-            Your reference number<br><strong>HDJ2123F</strong>
+            Your reference number<br><strong><%= @application.urn %></strong>
           </div>
         </div>
 

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -45,6 +45,14 @@ FactoryBot.define do
     after(:build) do |applicant|
       build(:address, addressable: applicant)
     end
+
+    factory :teacher do
+      application_route { "teacher" }
+    end
+
+    factory :salaried_trainee do
+      application_route { "salaried_trainee" }
+    end
   end
 
   trait :salaried_trainee do

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -16,7 +16,14 @@
 FactoryBot.define do
   factory :application do
     application_date { Faker::Date.in_date_period }
-    urn { Urn.new }
     applicant
+
+    factory :teacher_application do
+      applicant { build(:teacher) }
+    end
+
+    factory :salaried_trainee_application do
+      applicant { build(:salaried_trainee) }
+    end
   end
 end

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -9,6 +9,7 @@ module Applicants
     subject(:model) { described_class.new(params) }
 
     describe "validations" do
+      it { is_expected.to validate_presence_of(:application_route) }
       it { is_expected.to validate_presence_of(:given_name) }
       it { is_expected.to validate_presence_of(:family_name) }
       it { is_expected.to validate_presence_of(:email_address) }
@@ -33,6 +34,7 @@ module Applicants
       describe "save!" do
         let(:params) do
           {
+            application_route: "teacher",
             given_name: "John",
             family_name: "Smith",
             email_address: "john@email.com",

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -19,14 +19,28 @@ RSpec.describe Application do
   it { is_expected.to validate_presence_of(:application_date) }
 
   describe "#urn" do
-    subject(:application) { described_class.new }
+    it "is blank before creation" do
+      application = build(:teacher_application)
 
-    it "is not blank on instantiation" do
+      expect(application.urn).to be_blank
+    end
+
+    it "is present after creation" do
+      application = create(:teacher_application)
+
       expect(application.urn).to be_present
     end
 
-    it "starts with IRP" do
-      expect(application.urn.value).to match(/\AIRP[ABCDEFHJKLMNPRSTUV23456789]{6}\z/)
+    it "matches the required format for a teacher" do
+      application = create(:teacher_application)
+
+      expect(application.urn).to match(/^IRPTE[A-Z0-9]{6}$/)
+    end
+
+    it "matches the required format for a trainee" do
+      application = create(:salaried_trainee_application)
+
+      expect(application.urn).to match(/^IRPLT[A-Z0-9]{6}$/)
     end
   end
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Application do
     end
 
     it "starts with IRP" do
-      expect(application.urn.value).to match(/\AIRP [ABCDEFHJKLMNPRSTUV23456789]{6}\z/)
+      expect(application.urn.value).to match(/\AIRP[ABCDEFHJKLMNPRSTUV23456789]{6}\z/)
     end
   end
 

--- a/spec/models/urn_spec.rb
+++ b/spec/models/urn_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Urn do
   context "When a value is given" do
-    subject(:urn) { described_class.new("IRP 123456") }
+    subject(:urn) { described_class.new("IRP123456") }
 
     it "has a value" do
       expect(urn.value).to be_present
@@ -14,11 +14,11 @@ RSpec.describe Urn do
     end
 
     it "generates a Urn with a length of 8" do
-      expect(urn.value.length).to eq(10)
+      expect(urn.value.length).to eq(9)
     end
 
     it "generates a Urn with a suffix of 6 characters" do
-      expect(urn.value[4..].length).to eq(6)
+      expect(urn.value[4..].length).to eq(5)
     end
 
     it "generates a Urn with a suffix of only characters in the CHARSET" do
@@ -38,13 +38,13 @@ RSpec.describe Urn do
 
   describe ".dump" do
     it "returns the given value" do
-      expect(described_class.dump(described_class.new("IRP G2345"))).to eq("IRP G2345")
+      expect(described_class.dump(described_class.new("IRPG2345"))).to eq("IRPG2345")
     end
   end
 
   describe ".load" do
     it "returns the given value when `value` is not `nil`" do
-      expect(described_class.load("IRP G2345")).to eq(described_class.new("IRP G2345"))
+      expect(described_class.load("IRPG2345")).to eq(described_class.new("IRPG2345"))
     end
   end
 end

--- a/spec/models/urn_spec.rb
+++ b/spec/models/urn_spec.rb
@@ -3,42 +3,36 @@
 require "rails_helper"
 
 RSpec.describe Urn do
+  subject(:urn) { described_class.generate(applicant_type) }
+
   describe ".generate" do
     context 'when applicant type is "teacher"' do
+      let(:applicant_type) { "teacher" }
+
       it "generates a URN with the correct prefix and suffix" do
-        expect(described_class.generate("teacher")).to match(/^IRPTE[A-Z0-9]{6}$/)
+        expect(urn).to match(/^IRPTE[A-Z0-9]{6}$/)
+      end
+
+      it "generates a Urn with a suffix of only characters in the CHARSET" do
+        charset = %w[A B C D E F H J K L M N P R S T U V 0 1 2 3 4 5 6 7 8 9]
+
+        expect(urn[4..].chars).to all(be_in(charset))
       end
     end
 
     context 'when applicant type is "salaried_trainee"' do
+      let(:applicant_type) { "salaried_trainee" }
+
       it "generates a URN with the correct prefix and suffix" do
-        expect(described_class.generate("salaried_trainee")).to match(/^IRPLT[A-Z0-9]{6}$/)
+        expect(urn).to match(/^IRPLT[A-Z0-9]{6}$/)
       end
     end
 
     context "when an invalid applicant type is provided" do
+      let(:applicant_type) { "invalid_type" }
+
       it "raises an ArgumentError" do
-        expect { described_class.generate("invalid_type") }.to raise_error(ArgumentError, "Invalid applicant type: invalid_type")
-      end
-    end
-  end
-
-  describe ".applicant_type_code" do
-    context 'when applicant type is "teacher"' do
-      it "returns the correct code" do
-        expect(described_class.applicant_type_code("teacher")).to eq("TE")
-      end
-    end
-
-    context 'when applicant type is "salaried_trainee"' do
-      it "returns the correct code" do
-        expect(described_class.applicant_type_code("salaried_trainee")).to eq("LT")
-      end
-    end
-
-    context "when an invalid applicant type is provided" do
-      it "raises an ArgumentError" do
-        expect { described_class.applicant_type_code("invalid_type") }.to raise_error(ArgumentError, "Invalid applicant type: invalid_type")
+        expect { urn }.to raise_error(ArgumentError, "Invalid applicant type: invalid_type")
       end
     end
   end

--- a/spec/models/urn_spec.rb
+++ b/spec/models/urn_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Urn do
       let(:applicant_type) { "teacher" }
 
       it "generates a URN with the correct prefix and suffix" do
-        expect(urn).to match(/^IRPTE[A-Z0-9]{6}$/)
+        expect(urn).to match(/^IRPTE[0-9]{6}$/)
       end
 
       it "generates a Urn with a suffix of only characters in the CHARSET" do
-        charset = %w[A B C D E F H J K L M N P R S T U V 0 1 2 3 4 5 6 7 8 9]
+        charset = %w[0 1 2 3 4 5 6 7 8 9]
 
-        expect(urn[4..].chars).to all(be_in(charset))
+        expect(urn[5..].chars).to all(be_in(charset))
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Urn do
       let(:applicant_type) { "salaried_trainee" }
 
       it "generates a URN with the correct prefix and suffix" do
-        expect(urn).to match(/^IRPLT[A-Z0-9]{6}$/)
+        expect(urn).to match(/^IRPLT[0-9]{6}$/)
       end
     end
 

--- a/spec/models/urn_spec.rb
+++ b/spec/models/urn_spec.rb
@@ -1,50 +1,45 @@
-# spec/models/urn_spec.rb
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Urn do
-  context "When a value is given" do
-    subject(:urn) { described_class.new("IRP123456") }
-
-    it "has a value" do
-      expect(urn.value).to be_present
+  describe ".generate" do
+    context 'when applicant type is "teacher"' do
+      it "generates a URN with the correct prefix and suffix" do
+        expect(described_class.generate("teacher")).to match(/^IRPTE[A-Z0-9]{6}$/)
+      end
     end
 
-    it "generates a Urn with a prefix of 'IRP'" do
-      expect(urn.value).to start_with("IRP")
+    context 'when applicant type is "salaried_trainee"' do
+      it "generates a URN with the correct prefix and suffix" do
+        expect(described_class.generate("salaried_trainee")).to match(/^IRPLT[A-Z0-9]{6}$/)
+      end
     end
 
-    it "generates a Urn with a length of 8" do
-      expect(urn.value.length).to eq(9)
-    end
-
-    it "generates a Urn with a suffix of 6 characters" do
-      expect(urn.value[4..].length).to eq(5)
-    end
-
-    it "generates a Urn with a suffix of only characters in the CHARSET" do
-      charset = %w[A B C D E F H J K L M N P R S T U V 0 1 2 3 4 5 6 7 8 9]
-
-      expect(urn.value[4..].chars).to all(be_in(charset))
+    context "when an invalid applicant type is provided" do
+      it "raises an ArgumentError" do
+        expect { described_class.generate("invalid_type") }.to raise_error(ArgumentError, "Invalid applicant type: invalid_type")
+      end
     end
   end
 
-  context "When a value is not given" do
-    subject(:urn) { described_class.new }
-
-    it "has a value" do
-      expect(urn.value).to be_present
+  describe ".applicant_type_code" do
+    context 'when applicant type is "teacher"' do
+      it "returns the correct code" do
+        expect(described_class.applicant_type_code("teacher")).to eq("TE")
+      end
     end
-  end
 
-  describe ".dump" do
-    it "returns the given value" do
-      expect(described_class.dump(described_class.new("IRPG2345"))).to eq("IRPG2345")
+    context 'when applicant type is "salaried_trainee"' do
+      it "returns the correct code" do
+        expect(described_class.applicant_type_code("salaried_trainee")).to eq("LT")
+      end
     end
-  end
 
-  describe ".load" do
-    it "returns the given value when `value` is not `nil`" do
-      expect(described_class.load("IRPG2345")).to eq(described_class.new("IRPG2345"))
+    context "when an invalid applicant type is provided" do
+      it "raises an ArgumentError" do
+        expect { described_class.applicant_type_code("invalid_type") }.to raise_error(ArgumentError, "Invalid applicant type: invalid_type")
+      end
     end
   end
 end

--- a/spec/requests/question_for_personal_details_spec.rb
+++ b/spec/requests/question_for_personal_details_spec.rb
@@ -6,7 +6,6 @@ module Applicants
       let(:valid_params) do
         {
           applicants_personal_detail: {
-            "application_route" => "teacher",
             "given_name" => "John",
             "family_name" => "Doe",
             "email_address" => "john@email.com",
@@ -24,6 +23,10 @@ module Applicants
             "date_of_birth(1i)" => "1990",
           },
         }
+      end
+
+      before do
+        set_applicant_route!
       end
 
       context "with valid params" do
@@ -57,6 +60,18 @@ module Applicants
           expect(response.body).to include("Personal information")
         end
       end
+
+      # rubocop:disable RSpec/AnyInstance
+      def set_applicant_route!
+        # TODO: Remove this stub when we can use Factories via FactoryBot
+        # The current implementation users the user session to store attributes, which
+        # is not ideal and should be changed next. For now we are stubbing the session
+        # to return the applicant details.
+        allow_any_instance_of(PersonalDetailsController).to receive(:session).and_return({
+          "application_route" => "teacher",
+        })
+      end
+      # rubocop:enable RSpec/AnyInstance
     end
   end
 end

--- a/spec/requests/question_for_personal_details_spec.rb
+++ b/spec/requests/question_for_personal_details_spec.rb
@@ -6,6 +6,7 @@ module Applicants
       let(:valid_params) do
         {
           applicants_personal_detail: {
+            "application_route" => "teacher",
             "given_name" => "John",
             "family_name" => "Doe",
             "email_address" => "john@email.com",


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/acwINfog/32-m-generate-urn-for-applications-on-submission

## Description

Updates the URN so the application number includes the prefix `LT` or `TE` depending
of the type of applicant.

For example, 

```ruby
Urn.generate('teacher')          # => "IRPTE123456"
Urn.generate('salaried_trainee') # => "IRPLT123456"
```

<img width="805" alt="image" src="https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/134513241/a51b7fff-6934-4a1e-856d-2c389ae69a96">




