### PR TITLE
Update association after ADR: the progress is linked to an Application

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -42,7 +42,7 @@ class Applicant < ApplicationRecord
     :home_office_checks_completed_at,
     :school_investigation_required,
     :school_checks_completed_at,
-    to: :applicant_progress
+    to: :application_progress
 
   def full_name
     "#{given_name} #{family_name}"

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -29,8 +29,6 @@ class Applicant < ApplicationRecord
   # TODO: Add validations here so that a final check is made on the validity of
   # the whole application.
 
-  has_one :applicant_progress, dependent: :destroy
-
   has_one :address, as: :addressable, dependent: :destroy
   accepts_nested_attributes_for :address
 

--- a/app/models/applicant_progress.rb
+++ b/app/models/applicant_progress.rb
@@ -12,12 +12,8 @@
 #  visa_investigation_required     :boolean
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
-#  applicant_id                    :bigint           not null
-#
-# Foreign Keys
-#
-#  fk_rails_...  (applicant_id => applicants.id)
+#  application_id                  :bigint           not null
 #
 class ApplicantProgress < ApplicationRecord
-  belongs_to :applicant
+  belongs_to :application
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -15,26 +15,18 @@
 #
 class Application < ApplicationRecord
   belongs_to :applicant
-  has_one :applicant_progress, dependent: :destroy
+  has_one :application_progress, dependent: :destroy
 
   validates :application_date, presence: true
 
   before_create :generate_urn
 
   def self.initialise_for_applicant!(applicant)
-    Application.create!(
+    create!(
       applicant: applicant,
       application_date: Date.current.to_s,
-      applicant_progress: ApplicantProgress.new,
+      application_progress: ApplicationProgress.new,
     )
-
-    # puts application.inspect
-    # application.save!
-    # create!(
-    #   applicant: applicant,
-    #   application_date: Date.current.to_s,
-    #   applicant_progress: ApplicantProgress.new
-    # )
   end
 
 private

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -15,16 +15,26 @@
 #
 class Application < ApplicationRecord
   belongs_to :applicant
+  has_one :applicant_progress, dependent: :destroy
 
   validates :application_date, presence: true
 
   before_create :generate_urn
 
   def self.initialise_for_applicant!(applicant)
-    create!(
+    Application.create!(
       applicant: applicant,
       application_date: Date.current.to_s,
+      applicant_progress: ApplicantProgress.new,
     )
+
+    # puts application.inspect
+    # application.save!
+    # create!(
+    #   applicant: applicant,
+    #   application_date: Date.current.to_s,
+    #   applicant_progress: ApplicantProgress.new
+    # )
   end
 
 private

--- a/app/models/application_progress.rb
+++ b/app/models/application_progress.rb
@@ -14,6 +14,6 @@
 #  updated_at                      :datetime         not null
 #  application_id                  :bigint           not null
 #
-class ApplicantProgress < ApplicationRecord
+class ApplicationProgress < ApplicationRecord
   belongs_to :application
 end

--- a/db/migrate/20230622150827_add_progress_references_to_application.rb
+++ b/db/migrate/20230622150827_add_progress_references_to_application.rb
@@ -1,0 +1,5 @@
+class AddProgressReferencesToApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :applicant_progresses, :application_id, :bigint
+  end
+end

--- a/db/migrate/20230622151859_remove_foreign_key_constraint_applicant_to_progress.rb
+++ b/db/migrate/20230622151859_remove_foreign_key_constraint_applicant_to_progress.rb
@@ -1,0 +1,5 @@
+class RemoveForeignKeyConstraintApplicantToProgress < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :applicant_progresses, :applicant_id, :bigint
+  end
+end

--- a/db/migrate/20230622163508_rename_table_applicant_progress_to_application_progress.rb
+++ b/db/migrate/20230622163508_rename_table_applicant_progress_to_application_progress.rb
@@ -1,0 +1,5 @@
+class RenameTableApplicantProgressToApplicationProgress < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :applicant_progresses, :application_progresses
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_22_151859) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_22_163508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,17 +25,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_22_151859) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable"
-  end
-
-  create_table "applicant_progresses", force: :cascade do |t|
-    t.date "initial_checks_completed_at"
-    t.boolean "visa_investigation_required"
-    t.date "home_office_checks_completed_at"
-    t.boolean "school_investigation_required"
-    t.date "school_checks_completed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "application_id", null: false
   end
 
   create_table "applicants", force: :cascade do |t|
@@ -55,6 +44,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_22_151859) do
     t.string "application_route"
     t.bigint "school_id"
     t.index ["school_id"], name: "index_applicants_on_school_id"
+  end
+
+  create_table "application_progresses", force: :cascade do |t|
+    t.date "initial_checks_completed_at"
+    t.boolean "visa_investigation_required"
+    t.date "home_office_checks_completed_at"
+    t.boolean "school_investigation_required"
+    t.date "school_checks_completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "application_id", null: false
   end
 
   create_table "applications", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_19_112449) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_22_151859) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,7 +28,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_112449) do
   end
 
   create_table "applicant_progresses", force: :cascade do |t|
-    t.bigint "applicant_id", null: false
     t.date "initial_checks_completed_at"
     t.boolean "visa_investigation_required"
     t.date "home_office_checks_completed_at"
@@ -36,7 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_112449) do
     t.date "school_checks_completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["applicant_id"], name: "index_applicant_progresses_on_applicant_id"
+    t.bigint "application_id", null: false
   end
 
   create_table "applicants", force: :cascade do |t|
@@ -75,7 +74,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_112449) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "applicant_progresses", "applicants"
   add_foreign_key "applicants", "schools"
   add_foreign_key "applications", "applicants"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,9 @@ Applicant.destroy_all if Rails.env.development?
 
 %i[with_salaried_trainee with_teacher].each do |route|
   Rails.logger.debug { "Creating #{route} applicants..." }
-  FactoryBot.create_list(:applicant_progress, 5, :with_initial_checks_completed, route)
-  FactoryBot.create_list(:applicant_progress, 5, :with_visa_investigation_required, route)
-  FactoryBot.create_list(:applicant_progress, 5, :with_home_office_checks_completed, route)
-  FactoryBot.create_list(:applicant_progress, 5, :with_school_investigation_required, route)
-  FactoryBot.create_list(:applicant_progress, 5, :with_school_checks_completed, route)
+  FactoryBot.create_list(:application_progress, 5, :with_initial_checks_completed, route)
+  FactoryBot.create_list(:application_progress, 5, :with_visa_investigation_required, route)
+  FactoryBot.create_list(:application_progress, 5, :with_home_office_checks_completed, route)
+  FactoryBot.create_list(:application_progress, 5, :with_school_investigation_required, route)
+  FactoryBot.create_list(:application_progress, 5, :with_school_checks_completed, route)
 end

--- a/spec/factories/applicant_progresses.rb
+++ b/spec/factories/applicant_progresses.rb
@@ -13,7 +13,7 @@
 #  application_id                  :bigint           not null
 #
 FactoryBot.define do
-  factory :applicant_progress do
+  factory :application_progress do
     # nop
   end
 

--- a/spec/factories/applicant_progresses.rb
+++ b/spec/factories/applicant_progresses.rb
@@ -22,28 +22,26 @@ FactoryBot.define do
   end
 
   trait :with_visa_investigation_required do
-    initial_checks_completed_at { rand(21..30).days.ago.to_date }
+    with_initial_checks_completed
+
     visa_investigation_required { true }
   end
 
   trait :with_home_office_checks_completed do
-    initial_checks_completed_at { rand(21..30).days.ago.to_date }
-    visa_investigation_required { true }
+    with_visa_investigation_required
+
     home_office_checks_completed_at { rand(11..20).days.ago.to_date }
   end
 
   trait :with_school_investigation_required do
-    initial_checks_completed_at { rand(21..30).days.ago.to_date }
-    visa_investigation_required { true }
-    home_office_checks_completed_at { rand(11..20).days.ago.to_date }
+    with_school_investigation_required
+
     school_investigation_required { true }
   end
 
   trait :with_school_checks_completed do
-    initial_checks_completed_at { rand(21..30).days.ago.to_date }
-    visa_investigation_required { true }
-    home_office_checks_completed_at { rand(11..20).days.ago.to_date }
-    school_investigation_required { true }
+    with_school_investigation_required
+
     school_checks_completed_at { rand(1..10).days.ago.to_date }
   end
 

--- a/spec/factories/applicant_progresses.rb
+++ b/spec/factories/applicant_progresses.rb
@@ -10,15 +10,11 @@
 #  visa_investigation_required     :boolean
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
-#  applicant_id                    :bigint           not null
-#
-# Foreign Keys
-#
-#  fk_rails_...  (applicant_id => applicants.id)
+#  application_id                  :bigint           not null
 #
 FactoryBot.define do
   factory :applicant_progress do
-    applicant
+    # nop
   end
 
   trait :with_initial_checks_completed do

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
   factory :application do
     application_date { Faker::Date.in_date_period }
     applicant
-    applicant_progress { build(:applicant_progress) }
+    application_progress { build(:application_progress) }
 
     factory :teacher_application do
       applicant { build(:teacher) }

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
   factory :application do
     application_date { Faker::Date.in_date_period }
     applicant
+    applicant_progress { build(:applicant_progress) }
 
     factory :teacher_application do
       applicant { build(:teacher) }


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/JaErYVUq/131-update-association-from-applicant-to-association-according-to-adr5

## Description

According to #73, the `ApplicationProgress` domain model is linked to the `Application` 
and not to the `Applicant`. This makes sense, as there is only progress once the `Application` 
has been created.

On this PR, I take the following steps:

1.  Update FK from `Applicant` to `Application` => `Application` to `ApplicationProgress`
2. Rename the table from `ApplicantProgress` to `ApplicationProgress`
3. Drop old column `applicant_id` on the `application_progress`

Although I am destroying one column, as we have no production data, there is no risk associated with the
database migrations.