### PR TITLE
Add a new dashboard widget for the subjects

### DIFF
--- a/app/models/kpis.rb
+++ b/app/models/kpis.rb
@@ -10,4 +10,8 @@ class Kpis
   def route_breakdown
     RouteBreakdownQuery.new.call
   end
+
+  def subject_breakdown
+    SubjectBreakdownQuery.new.call
+  end
 end

--- a/app/queries/subject_breakdown_query.rb
+++ b/app/queries/subject_breakdown_query.rb
@@ -1,0 +1,9 @@
+class SubjectBreakdownQuery
+  def initialize(relation = Applicant.all)
+    @relation = relation
+  end
+
+  def call
+    @relation.group(:subject).order("count_id DESC").count(:id)
+  end
+end

--- a/app/views/system_admin/dashboard/show.html.erb
+++ b/app/views/system_admin/dashboard/show.html.erb
@@ -14,4 +14,15 @@
       <% end %>
     </table>
   </div>
+  <div class="kpi-widget subjects">
+    <h3 class="title">Subjects</h3>
+    <table class="kpi-table">
+      <% @kpis.subject_breakdown.each do |k,v|%>
+        <tr>
+          <td><%= k.titleize %></td>
+          <td><%= v %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
 </div>

--- a/spec/features/admin_console/dashboard_spec.rb
+++ b/spec/features/admin_console/dashboard_spec.rb
@@ -19,13 +19,21 @@ describe "Dashboard" do
     then_i_can_see_the_route_breakdown_widget
   end
 
+  it "shows the Subject Breakdown widget" do
+    given_there_are_few_applications
+    given_i_am_signed_as_an_admin
+    when_i_am_in_the_dashboard_page
+    then_i_can_see_the_subject_breakdown_widget
+  end
+
   def given_there_are_5_applications
     create_list(:applicant, 5)
   end
 
   def given_there_are_few_applications
-    create_list(:applicant, 2, :teacher)
-    create_list(:applicant, 1, :salaried_trainee)
+    create(:applicant, :teacher, subject: :physics)
+    create(:applicant, :teacher, subject: :languages)
+    create(:applicant, :salaried_trainee, subject: :general_science)
   end
 
   def when_i_am_in_the_dashboard_page
@@ -45,6 +53,16 @@ describe "Dashboard" do
       expect(page).to have_content("Teacher")
       expect(page).to have_content("2")
       expect(page).to have_content("Salaried Trainee")
+      expect(page).to have_content("1")
+    end
+  end
+
+  def then_i_can_see_the_subject_breakdown_widget
+    within ".kpi-widget.subjects" do
+      expect(page).to have_content("Subjects")
+      expect(page).to have_content("General Science")
+      expect(page).to have_content("Languages")
+      expect(page).to have_content("Physics")
       expect(page).to have_content("1")
     end
   end

--- a/spec/queries/subject_breakdown_query_spec.rb
+++ b/spec/queries/subject_breakdown_query_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe SubjectBreakdownQuery, type: :model do
+  describe "#call" do
+    context "when there are a few applicants" do
+      before do
+        create(:applicant, subject: :physics)
+        create(:applicant, subject: :languages)
+        create(:applicant, subject: :general_science)
+      end
+
+      it "returns the correct subject breakdown" do
+        result = described_class.new.call
+
+        expect(result).to eq({
+          "physics" => 1,
+          "languages" => 1,
+          "general_science" => 1,
+        })
+      end
+    end
+
+    context "when there are no applicants" do
+      it "returns the empty hash breakdown" do
+        result = described_class.new.call
+
+        expect(result).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
Adds a new widget for the subjects breakdown

- Creates a new query object to obtain the subjects breakdown
- Adds a new widget to the dashboard to display the route breakdown
- Adds the necessary tests for the query object and system test for the widget view


## Trello Card Link

https://trello.com/c/nXkigy23
