### PR TITLE
Update README.md: `asdf` bundler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Once installed, run:
 asdf plugin add ruby
 asdf plugin add nodejs
 asdf plugin add yarn
+asdf plugin add bundler
 asdf install
 ```
 


### PR DESCRIPTION
### Description

Before being able to install `asdf` tools, we need to also add the `bundler` plugin.

