### PR TITLE
Update URN format to correct specs

### DIFF
--- a/app/models/kpis.rb
+++ b/app/models/kpis.rb
@@ -10,7 +10,7 @@ class Kpis
   def total_rejections
     ApplicationProgress.where.not(rejection_completed_at: nil).count
   end
-  
+
   def average_age
     AverageAgeQuery.new.call
   end

--- a/app/models/urn.rb
+++ b/app/models/urn.rb
@@ -6,9 +6,9 @@
 #
 # Example:
 #
-#   Urn.generate('teacher')          # => "IRP12345TE"
-#   Urn.generate('teacher')          # => "IRP12345TE"
-#   Urn.generate('salaried_trainee') # => "IRPLT12345"
+#   Urn.generate('teacher')          # => "IRPTE12345"
+#   Urn.generate('teacher')          # => "IRPTE12345"
+#   Urn.generate('salaried_trainee') # => "IRPST12345"
 #
 class Urn
   attr_reader :value
@@ -16,7 +16,7 @@ class Urn
 
   def self.generate(applicant_type)
     code = applicant_type_code(applicant_type)
-    PREFIX + Array.new(LENGTH) { CHARSET.sample }.join + code
+    PREFIX + code + Array.new(LENGTH) { CHARSET.sample }.join
   end
 
   CHARSET = %w[0 1 2 3 4 5 6 7 8 9].freeze
@@ -29,7 +29,7 @@ class Urn
     when "teacher"
       "TE"
     when "salaried_trainee"
-      "LT"
+      "ST"
     else
       raise(ArgumentError, "Invalid applicant type: #{applicant_type}")
     end

--- a/spec/features/admin_console/dashboard_spec.rb
+++ b/spec/features/admin_console/dashboard_spec.rb
@@ -18,7 +18,7 @@ describe "Dashboard" do
     when_i_am_in_the_dashboard_page
     then_i_can_see_the_total_rejections_widget
   end
-  
+
   it "shows the Average Age widget" do
     given_there_are_3_applicants_with_ages
     given_i_am_signed_as_an_admin
@@ -101,7 +101,7 @@ describe "Dashboard" do
     application = create(:application)
     create_list(:application_progress, 2, :with_rejection_completed, application:)
   end
-  
+
   def given_there_are_3_applicants_with_ages
     create(:applicant, date_of_birth: 35.years.ago)
     create(:applicant, date_of_birth: 45.years.ago)
@@ -125,7 +125,7 @@ describe "Dashboard" do
       expect(page).to have_content("2")
     end
   end
-  
+
   def then_i_can_see_the_average_age_widget
     within ".kpi-widget.age" do
       expect(page).to have_content("Average Age")

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe Application do
     it "matches the required format for a teacher" do
       application = create(:teacher_application)
 
-      expect(application.urn).to match(/^IRP[A-Z0-9]{5}TE$/)
+      expect(application.urn).to match(/^IRPTE[A-Z0-9]{5}$/)
     end
 
     it "matches the required format for a trainee" do
       application = create(:salaried_trainee_application)
 
-      expect(application.urn).to match(/^IRP[A-Z0-9]{5}LT$/)
+      expect(application.urn).to match(/^IRPST[A-Z0-9]{5}$/)
     end
   end
 

--- a/spec/models/urn_spec.rb
+++ b/spec/models/urn_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Urn do
       let(:applicant_type) { "teacher" }
 
       it "generates a URN with the correct prefix and suffix" do
-        expect(urn).to match(/^IRP[0-9]{5}TE$/)
+        expect(urn).to match(/^IRPTE[0-9]{5}$/)
       end
 
       it "generates a Urn with a suffix of only characters in the CHARSET" do
         charset = %w[0 1 2 3 4 5 6 7 8 9]
 
-        expect(urn[3..7].chars).to all(be_in(charset))
+        expect(urn[5..9].chars).to all(be_in(charset))
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Urn do
       let(:applicant_type) { "salaried_trainee" }
 
       it "generates a URN with the correct prefix and suffix" do
-        expect(urn).to match(/^IRP[0-9]{5}LT$/)
+        expect(urn).to match(/^IRPST[0-9]{5}$/)
       end
     end
 


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/acwINfog/32-m-generate-urn-for-applications-on-submission

### Description

Moves back the TE|ST suffix after the `IRP` prefix.

```ruby
# Urn represents a Uniform Resource Name (URN) generator.
# It generates a URN with a fixed prefix and a random alphanumeric suffix.
#
#
# Example:
#
#   Urn.generate('teacher')          # => "IRPTE12345"
#   Urn.generate('teacher')          # => "IRPTE12345"
#   Urn.generate('salaried_trainee') # => "IRPST12345"
#
```

