### PR TITLE
Use Okcomputer gem for Healthchecks

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -85,7 +85,7 @@ jobs:
           type=registry,ref=${{env.DOCKER_IMAGE}}:main
           type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
           type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
-        build-args: COMMIT_SHA=${{ github.sha }}
+        build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
 
     - name: Push ${{ env.DOCKER_IMAGE }} images for review
       if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby "3.1.3"
 gem "bootsnap", require: false
 gem "foreman"
 gem "jbuilder"
+gem "okcomputer"
 gem "pg", "~> 1.1"
 gem "puma", "~> 6.3"
 gem "rails", "~> 7.0.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,7 @@ GEM
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
+    okcomputer (1.18.4)
     pagy (6.0.4)
     parallel (1.23.0)
     parser (3.2.2.1)
@@ -379,6 +380,7 @@ DEPENDENCIES
   jbuilder
   launchy
   notifications-ruby-client
+  okcomputer
   pg (~> 1.1)
   phonelib
   pry-byebug

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,3 +1,5 @@
 OkComputer.mount_at = "healthcheck"
 
-OkComputer::Registry.register "postgresql", OkComputer::ActiveRecordCheck.new
+OkComputer::Registry.register("version", OkComputer::AppVersionCheck.new(env: "COMMIT_SHA"))
+
+OkComputer.make_optional(%w[version])

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,3 @@
+OkComputer.mount_at = "healthcheck"
+
+OkComputer::Registry.register "postgresql", OkComputer::ActiveRecordCheck.new

--- a/spec/requests/healthchecks_spec.rb
+++ b/spec/requests/healthchecks_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "Healthcheck" do
+  it "responds successfully" do
+    get "/healthcheck"
+
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/healthchecks_spec.rb
+++ b/spec/requests/healthchecks_spec.rb
@@ -1,8 +1,14 @@
 require "rails_helper"
 
-RSpec.describe "Healthcheck" do
-  it "responds successfully" do
+RSpec.describe "Healthchecks" do
+  it "default request responds successfully when the rails server is up" do
     get "/healthcheck"
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "database checkpoint responds successfully when database is up" do
+    get "/healthcheck/database"
 
     expect(response).to have_http_status(:ok)
   end


### PR DESCRIPTION
Supersedes #83

### Description

Following [suggestion](https://github.com/DFE-Digital/get-a-teacher-relocation-payment/pull/83#pullrequestreview-1498160709) by @thomasleese, provides healchecks via [okcomputer gem](https://github.com/sportngin/okcomputer). 

The current configuration enables the following endpoints:

1. /healthcheck/default

_This Healthcheck only validates that the applications is `up` regardless of the database._

```
default: PASSED Application is running (0.000s)
```

2. /healcheck/database

```
database: PASSED Schema version: 20230628135130 (0.003s)
```

3. /healthcheck/version

```
version: PASSED Version: 10dd57d99596dcc0518a9269899aaa6413f30a6a (0.000s) (OPTIONAL)
```

4. /healthcheck/all

```
Default Collection
  database: PASSED Schema version: 20230628135130 (0.003s)
  default: PASSED Application is running (0.000s)
  version: PASSED Version: 10dd57d99596dcc0518a9269899aaa6413f30a6a (0.000s) (OPTIONAL)
```

### Example of JSON formatting

If we append `.json` at the end it will reformat the output accordingly.

```
# /healcheck/all
{
    "default": {
        "message": "Application is running",
        "success": true,
        "time": 0.000003000008291564882
    },
    "database": {
        "message": "Schema version: 20230628135130",
        "success": true,
        "time": 0.0020729999960167333
    },
    "version": {
        "message": "Version: 10dd57d99596dcc0518a9269899aaa6413f30a6a",
        "success": true,
        "time": 0.00001200000406242907
    }
}
```

Closes #83 
