### PR TITLE
Move FactoryBot out of the development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,9 +36,9 @@ group :test do
   gem "shoulda-matchers", "~> 5.0"
   gem "simplecov", require: false
 end
+gem "factory_bot_rails"
 
 group :development, :test do
-  gem "factory_bot_rails"
   gem "rubocop-govuk", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,10 @@
 
 # In order to reload the data, please run:
 #
-# $ bundle exec rails db:seeds:replant
+# $ bundle exec rails db:seed:replant
 #
+
+require "factory_bot_rails"
 
 %i[
   teacher_application


### PR DESCRIPTION
## Description
We need to move the factory_bot_rails gem out of development group so it can
be installed when in production environments and the database seeding works.
