### PR TITLE
Remove county from Address (address User Research)

### DIFF
--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -30,7 +30,6 @@ module Applicants
         :school_address_line_1,
         :school_address_line_2,
         :school_city,
-        :school_county,
         :school_postcode,
       )
     end

--- a/app/controllers/applicants/personal_details_controller.rb
+++ b/app/controllers/applicants/personal_details_controller.rb
@@ -32,7 +32,6 @@ module Applicants
         :address_line_1,
         :address_line_2,
         :city,
-        :county,
         :postcode,
         *DOB_CONVERSION.keys,
       ).transform_keys do |key|

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -9,7 +9,6 @@
 #  address_line_2   :string
 #  addressable_type :string           not null
 #  city             :string
-#  county           :string
 #  postcode         :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/app/models/applicants/employment_detail.rb
+++ b/app/models/applicants/employment_detail.rb
@@ -8,7 +8,6 @@ module Applicants
                   :school_address_line_1,
                   :school_address_line_2,
                   :school_city,
-                  :school_county,
                   :school_postcode,
                   :applicant
 
@@ -26,7 +25,6 @@ module Applicants
           address_line_1: school_address_line_1,
           address_line_2: school_address_line_2,
           city: school_city,
-          county: school_county,
           postcode: school_postcode,
         },
       )

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -5,7 +5,7 @@ module Applicants
     include ActiveModel::Model
     attr_accessor :given_name, :family_name, :email_address, :phone_number,
                   :day, :month, :year, :sex, :passport_number, :nationality, :address_line_1,
-                  :address_line_2, :city, :county, :postcode
+                  :address_line_2, :city, :postcode
 
     SEX_OPTIONS = %w[female male].freeze
 
@@ -50,7 +50,6 @@ module Applicants
           address_line_1:,
           address_line_2:,
           city:,
-          county:,
           postcode:,
         },
       )

--- a/app/views/applicants/employment_details/new.html.erb
+++ b/app/views/applicants/employment_details/new.html.erb
@@ -15,7 +15,6 @@
         <%= f.govuk_text_field :school_address_line_1, label: { text: t("applicants.employment_details.address_line_1"), size: "s"} %>
         <%= f.govuk_text_field :school_address_line_2, label: { text: t("applicants.employment_details.address_line_2"), size: "s"} %>
         <%= f.govuk_text_field :school_city, label: { text: t("applicants.employment_details.city"), size: "s"} %>
-        <%= f.govuk_text_field :school_county, label: { text: t("applicants.employment_details.county"), size: "s"} %>
         <%= f.govuk_text_field :school_postcode, label: { text: t("applicants.employment_details.postcode"), size: "s"} %>
       <% end %>
 

--- a/app/views/applicants/personal_details/new.html.erb
+++ b/app/views/applicants/personal_details/new.html.erb
@@ -21,7 +21,6 @@
         <%= f.govuk_text_field :address_line_1, label: { text: t("applicants.personal_details.address_line_1") , size: "s"} %>
         <%= f.govuk_text_field :address_line_2, label: { text: t("applicants.personal_details.address_line_2") , size: "s"} %>
         <%= f.govuk_text_field :city, label: { text: t("applicants.personal_details.city") , size: "s"} %>
-        <%= f.govuk_text_field :county, label: { text: t("applicants.personal_details.county") , size: "s"} %>
         <%= f.govuk_text_field :postcode, label: { text: t("applicants.personal_details.postcode"), size: "s"} %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,6 @@ en:
       address_line_1: Address line 1
       address_line_2: Address line 2 (optional)
       city: Town or city
-      county: County (optional)
       postcode: Postcode
     personal_details:
       title: Personal information
@@ -77,7 +76,6 @@ en:
       address_line_1: Address line 1
       address_line_2: Address line 2 (Optional)
       city: Town or city
-      county: County (optional)
       postcode: Postcode
       nationality: Select your nationality
       sex: Select your sex

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,7 +57,7 @@ en:
         title:
           teacher: Enter the name of the school where you are employed as a teacher
           salaried_trainee: Enter the name of the school where you are employed as a trainee teacher
-      headteacher: Enter the name of the Headteacher or Principal of the school
+      headteacher: Enter the name of the headteacher or principal of the school
       address: Enter the school address
       address_line_1: Address line 1
       address_line_2: Address line 2 (Optional)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,7 @@ en:
       headteacher: Enter the name of the headteacher or principal of the school
       address: Enter the school address
       address_line_1: Address line 1
-      address_line_2: Address line 2 (Optional)
+      address_line_2: Address line 2 (optional)
       city: Town or city
       county: County (optional)
       postcode: Postcode

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
       city: Town or city
       county: County (optional)
       postcode: Postcode
-      nationality: Select your Nationality
+      nationality: Select your nationality
       sex: Select your sex
       passport: Enter your passport number, as it appears on your passport
     subjects:

--- a/db/migrate/20230705133229_remove_county_from_address.rb
+++ b/db/migrate/20230705133229_remove_county_from_address.rb
@@ -1,0 +1,5 @@
+class RemoveCountyFromAddress < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :addresses, :county, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_04_113813) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_05_133229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,7 +20,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_113813) do
     t.string "address_line_1"
     t.string "address_line_2"
     t.string "city"
-    t.string "county"
     t.string "postcode"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -7,7 +7,6 @@
 #  address_line_2   :string
 #  addressable_type :string           not null
 #  city             :string
-#  county           :string
 #  postcode         :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
@@ -18,7 +17,6 @@ FactoryBot.define do
     address_line_1 { Faker::Address.street_address }
     address_line_2 { Faker::Address.secondary_address }
     city { Faker::Address.city }
-    county { Faker::Address.state }
     postcode { Faker::Address.postcode }
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -9,7 +9,6 @@
 #  address_line_2   :string
 #  addressable_type :string           not null
 #  city             :string
-#  county           :string
 #  postcode         :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/spec/models/applicants/employment_detail_spec.rb
+++ b/spec/models/applicants/employment_detail_spec.rb
@@ -23,7 +23,6 @@ module Applicants
           school_address_line_1: "Test Address Line 1",
           school_address_line_2: "Test Address Line 2",
           school_city: "Test City",
-          school_county: "Test County",
           school_postcode: "SE2 0BA",
         }
       end

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -20,7 +20,6 @@ module Applicants
       it { is_expected.to validate_presence_of(:address_line_1) }
       it { is_expected.not_to validate_presence_of(:address_line_2) }
       it { is_expected.to validate_presence_of(:city) }
-      it { is_expected.not_to validate_presence_of(:county) }
       it { is_expected.to validate_presence_of(:postcode) }
 
       it {
@@ -47,7 +46,6 @@ module Applicants
             address_line_1: "1 High Street",
             address_line_2: "Flat 1",
             city: "London",
-            county: "London",
             postcode: "SW1A 1AA",
           }
         end

--- a/spec/requests/question_for_employment_details_spec.rb
+++ b/spec/requests/question_for_employment_details_spec.rb
@@ -12,7 +12,6 @@ module Applicants
             "school_address_line_2" => "second line",
             "school_city" => "London",
             "school_postcode" => "E1 8QS",
-            "school_county" => "County",
           },
         }
       end

--- a/spec/requests/question_for_personal_details_spec.rb
+++ b/spec/requests/question_for_personal_details_spec.rb
@@ -16,7 +16,6 @@ module Applicants
             "address_line_1" => "7 McLeud",
             "address_line_2" => "second line",
             "city" => "London",
-            "county" => "County",
             "postcode" => "E1 8QS",
             "date_of_birth(3i)" => "1",
             "date_of_birth(2i)" => "1",

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -57,7 +57,6 @@ RSpec.shared_context "with common application form steps" do
     fill_in("applicants_personal_detail[address_line_1]", with: "12 Park Gardens")
     fill_in("applicants_personal_detail[address_line_2]", with: "Office 20")
     fill_in("applicants_personal_detail[city]", with: "London")
-    fill_in("applicants_personal_detail[county]", with: "A county")
     fill_in("applicants_personal_detail[postcode]", with: "AS1 1AA")
     select("English")
     choose("Male")
@@ -72,7 +71,6 @@ RSpec.shared_context "with common application form steps" do
     fill_in("applicants_employment_detail[school_address_line_1]", with: "1, McSchool Street")
     fill_in("applicants_employment_detail[school_address_line_2]", with: "Schoolville")
     fill_in("applicants_employment_detail[school_city]", with: "Schooltown")
-    fill_in("applicants_employment_detail[school_county]", with: "Schoolshire")
     fill_in("applicants_employment_detail[school_postcode]", with: "SC1 1AA")
 
     click_button("Submit application")


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/iLM73Wos/140-edits-to-the-employment-page-reviewed-by-laura
https://trello.com/c/IaH6ZW93/139-edits-to-personal-information-page-reviewed-by-laura

## Description

Removes `County` from the applicant journey (entering address); as per User Research
findings this seems to be confusing for our users.

It also perform minor updates the content copy for the personal info page.

