### PR TITLE
Navigating back from the last question

### DIFF
--- a/app/controllers/applicants/application_routes_controller.rb
+++ b/app/controllers/applicants/application_routes_controller.rb
@@ -3,7 +3,7 @@
 module Applicants
   class ApplicationRoutesController < ApplicationController
     def new
-      @application_route = ApplicationRoute.new
+      @application_route = ApplicationRoute.new(application_route: params[:application_route])
     end
 
     def create

--- a/app/controllers/applicants/contract_details_controller.rb
+++ b/app/controllers/applicants/contract_details_controller.rb
@@ -5,7 +5,7 @@ module Applicants
     before_action :check_teacher!
 
     def new
-      @contract_detail = ContractDetail.new
+      @contract_detail = ContractDetail.new(one_year: params[:one_year])
     end
 
     def create

--- a/app/controllers/applicants/contract_details_controller.rb
+++ b/app/controllers/applicants/contract_details_controller.rb
@@ -2,6 +2,7 @@
 
 module Applicants
   class ContractDetailsController < ApplicationController
+    before_action :check_application!
     before_action :check_teacher!
 
     def new

--- a/app/controllers/applicants/contract_start_dates_controller.rb
+++ b/app/controllers/applicants/contract_start_dates_controller.rb
@@ -3,7 +3,7 @@
 module Applicants
   class ContractStartDatesController < ApplicationController
     def new
-      @contract_start_date = ContractStartDate.new
+      @contract_start_date = ContractStartDate.new(contract_start_date: current_application.start_date)
     end
 
     def create

--- a/app/controllers/applicants/contract_start_dates_controller.rb
+++ b/app/controllers/applicants/contract_start_dates_controller.rb
@@ -2,6 +2,7 @@
 
 module Applicants
   class ContractStartDatesController < ApplicationController
+    before_action :check_application!
     def new
       @contract_start_date = ContractStartDate.new(contract_start_date: current_application.start_date)
     end

--- a/app/controllers/applicants/employment_details_controller.rb
+++ b/app/controllers/applicants/employment_details_controller.rb
@@ -2,6 +2,7 @@
 
 module Applicants
   class EmploymentDetailsController < ApplicationController
+    before_action :check_application!
     def new
       @employment_detail = EmploymentDetail.new
     end

--- a/app/controllers/applicants/entry_dates_controller.rb
+++ b/app/controllers/applicants/entry_dates_controller.rb
@@ -3,7 +3,7 @@
 module Applicants
   class EntryDatesController < ApplicationController
     def new
-      @entry_date = EntryDate.new
+      @entry_date = EntryDate.new(entry_date: current_application.date_of_entry)
     end
 
     def create

--- a/app/controllers/applicants/entry_dates_controller.rb
+++ b/app/controllers/applicants/entry_dates_controller.rb
@@ -2,6 +2,8 @@
 
 module Applicants
   class EntryDatesController < ApplicationController
+    before_action :check_application!
+
     def new
       @entry_date = EntryDate.new(entry_date: current_application.date_of_entry)
     end

--- a/app/controllers/applicants/personal_details_controller.rb
+++ b/app/controllers/applicants/personal_details_controller.rb
@@ -3,7 +3,7 @@
 module Applicants
   class PersonalDetailsController < ApplicationController
     def new
-      @personal_detail = PersonalDetail.new
+      @personal_detail = PersonalDetail.new(applicant: current_application.applicant)
     end
 
     def create

--- a/app/controllers/applicants/personal_details_controller.rb
+++ b/app/controllers/applicants/personal_details_controller.rb
@@ -2,6 +2,8 @@
 
 module Applicants
   class PersonalDetailsController < ApplicationController
+    before_action :check_application!
+
     def new
       @personal_detail = PersonalDetail.new(applicant: current_application.applicant)
     end

--- a/app/controllers/applicants/salaried_course_details_controller.rb
+++ b/app/controllers/applicants/salaried_course_details_controller.rb
@@ -2,6 +2,8 @@
 
 module Applicants
   class SalariedCourseDetailsController < ApplicationController
+    before_action :check_application!
+
     before_action :check_trainee!
 
     def new

--- a/app/controllers/applicants/salaried_course_details_controller.rb
+++ b/app/controllers/applicants/salaried_course_details_controller.rb
@@ -5,7 +5,7 @@ module Applicants
     before_action :check_trainee!
 
     def new
-      @salaried_course_detail = SalariedCourseDetail.new
+      @salaried_course_detail = SalariedCourseDetail.new(eligible_course: params[:eligible_course])
     end
 
     def create

--- a/app/controllers/applicants/school_details_controller.rb
+++ b/app/controllers/applicants/school_details_controller.rb
@@ -5,7 +5,7 @@ module Applicants
     before_action :check_teacher!
 
     def new
-      @school_detail = SchoolDetail.new
+      @school_detail = SchoolDetail.new(state_funded_secondary_school: params[:state_funded_secondary_school])
     end
 
     def create

--- a/app/controllers/applicants/school_details_controller.rb
+++ b/app/controllers/applicants/school_details_controller.rb
@@ -2,6 +2,8 @@
 
 module Applicants
   class SchoolDetailsController < ApplicationController
+    before_action :check_application!
+
     before_action :check_teacher!
 
     def new

--- a/app/controllers/applicants/subjects_controller.rb
+++ b/app/controllers/applicants/subjects_controller.rb
@@ -2,6 +2,7 @@
 
 module Applicants
   class SubjectsController < ApplicationController
+    before_action :check_application!
     def new
       @subject = Subject.new(subject: current_application.subject)
     end

--- a/app/controllers/applicants/subjects_controller.rb
+++ b/app/controllers/applicants/subjects_controller.rb
@@ -3,7 +3,7 @@
 module Applicants
   class SubjectsController < ApplicationController
     def new
-      @subject = Subject.new
+      @subject = Subject.new(subject: current_application.subject)
     end
 
     def create

--- a/app/controllers/applicants/submissions_controller.rb
+++ b/app/controllers/applicants/submissions_controller.rb
@@ -2,6 +2,8 @@
 
 module Applicants
   class SubmissionsController < ApplicationController
+    before_action :check_application!
+
     def show
       @application = current_application
 

--- a/app/controllers/applicants/submissions_controller.rb
+++ b/app/controllers/applicants/submissions_controller.rb
@@ -3,7 +3,9 @@
 module Applicants
   class SubmissionsController < ApplicationController
     def show
-      @application = current_applicant.application
+      @application = current_application
+
+      session[:application_id] = nil
     end
   end
 end

--- a/app/controllers/applicants/visas_controller.rb
+++ b/app/controllers/applicants/visas_controller.rb
@@ -2,6 +2,7 @@
 
 module Applicants
   class VisasController < ApplicationController
+    before_action :check_application!
     def new
       @visa = Visa.new(visa_type: current_application.visa_type)
     end

--- a/app/controllers/applicants/visas_controller.rb
+++ b/app/controllers/applicants/visas_controller.rb
@@ -3,7 +3,7 @@
 module Applicants
   class VisasController < ApplicationController
     def new
-      @visa = Visa.new
+      @visa = Visa.new(visa_type: current_application.visa_type)
     end
 
     def create

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,12 @@ class ApplicationController < ActionController::Base
   delegate :application_route, to: :current_application
   helper_method :application_route
 
+  def check_application!
+    return if session["application_id"]
+
+    redirect_to(root_path)
+  end
+
   def current_application
     Application.find(session["application_id"])
   end

--- a/app/helpers/personal_detail_helper.rb
+++ b/app/helpers/personal_detail_helper.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module PersonalDetailHelper
-  def nationality_options
-    nationalities = NATIONALITIES.dup
-    options_for_select(nationalities.unshift(nil))
-  end
-end

--- a/app/helpers/visa_helper.rb
+++ b/app/helpers/visa_helper.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module VisaHelper
-  def visa_options
-    visas = Applicants::Visa::VISA_OPTIONS.dup
-    options_for_select(visas.unshift(nil))
-  end
-end

--- a/app/models/applicants/contract_start_date.rb
+++ b/app/models/applicants/contract_start_date.rb
@@ -11,6 +11,12 @@ module Applicants
 
     validates :contract_start_date, presence: true
 
+    def contract_start_date=(contract_start_date)
+      @day = contract_start_date&.day
+      @month = contract_start_date&.month
+      @year = contract_start_date&.year
+    end
+
     def contract_start_date
       Date.new(year.to_i, month.to_i, day.to_i)
     rescue StandardError

--- a/app/models/applicants/entry_date.rb
+++ b/app/models/applicants/entry_date.rb
@@ -11,6 +11,12 @@ module Applicants
       DayMonthYearDateValidator.new.validate(record)
     end
 
+    def entry_date=(entry_date)
+      @day = entry_date&.day
+      @month = entry_date&.month
+      @year = entry_date&.year
+    end
+
     def entry_date
       return InvalidDate.new(day:, month:, year:) if year.blank?
 

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -35,23 +35,23 @@ module Applicants
       InvalidDate.new(day:, month:, year:)
     end
 
-    def self.load(applicant)
-      new.tap do |model|
-        model.given_name = applicant.given_name
-        model.family_name = applicant.family_name
-        model.email_address = applicant.email_address
-        model.phone_number = applicant.phone_number
-        model.day = applicant.date_of_birth.day
-        model.month = applicant.date_of_birth.month
-        model.year = applicant.date_of_birth.year
-        model.sex = applicant.sex
-        model.passport_number = applicant.passport_number
-        model.nationality = applicant.nationality
-        model.address_line_1 = applicant.address.address_line_1
-        model.address_line_2 = applicant.address.address_line_2
-        model.city = applicant.address.city
-        model.postcode = applicant.address.postcode
-      end
+    def applicant=(applicant)
+      return unless applicant
+
+      self.given_name = applicant.given_name
+      self.family_name = applicant.family_name
+      self.email_address = applicant.email_address
+      self.phone_number = applicant.phone_number
+      self.day = applicant.date_of_birth.day
+      self.month = applicant.date_of_birth.month
+      self.year = applicant.date_of_birth.year
+      self.sex = applicant.sex
+      self.passport_number = applicant.passport_number
+      self.nationality = applicant.nationality
+      self.address_line_1 = applicant.address.address_line_1
+      self.address_line_2 = applicant.address.address_line_2
+      self.city = applicant.address.city
+      self.postcode = applicant.address.postcode
     end
 
     def save!(application:)

--- a/app/models/applicants/personal_detail.rb
+++ b/app/models/applicants/personal_detail.rb
@@ -35,6 +35,25 @@ module Applicants
       InvalidDate.new(day:, month:, year:)
     end
 
+    def self.load(applicant)
+      new.tap do |model|
+        model.given_name = applicant.given_name
+        model.family_name = applicant.family_name
+        model.email_address = applicant.email_address
+        model.phone_number = applicant.phone_number
+        model.day = applicant.date_of_birth.day
+        model.month = applicant.date_of_birth.month
+        model.year = applicant.date_of_birth.year
+        model.sex = applicant.sex
+        model.passport_number = applicant.passport_number
+        model.nationality = applicant.nationality
+        model.address_line_1 = applicant.address.address_line_1
+        model.address_line_2 = applicant.address.address_line_2
+        model.city = applicant.address.city
+        model.postcode = applicant.address.postcode
+      end
+    end
+
     def save!(application:)
       Applicant.create!(
         application: application,

--- a/app/views/applicants/contract_details/new.html.erb
+++ b/app/views/applicants/contract_details/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :back_link do %>
+  <%= link_to 'Back', new_applicants_school_detail_path(state_funded_secondary_school: "yes"), class: 'govuk-back-link' %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @contract_detail, local: true) do |f| %>

--- a/app/views/applicants/contract_start_dates/new.html.erb
+++ b/app/views/applicants/contract_start_dates/new.html.erb
@@ -1,9 +1,13 @@
+<% content_for :back_link do %>
+  <%= link_to 'Back', new_applicants_contract_detail_path, class: 'govuk-back-link' %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @contract_start_date, local: true) do |f| %>
 
       <%= f.govuk_error_summary %>
-      
+
       <%= f.govuk_date_field :contract_start_date, legend: { text: t("applicants.contract_start_dates.title"), tag: "h1", size: "l" } %>
 
       <%= f.govuk_submit %>

--- a/app/views/applicants/contract_start_dates/new.html.erb
+++ b/app/views/applicants/contract_start_dates/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link do %>
-  <%= link_to 'Back', new_applicants_contract_detail_path, class: 'govuk-back-link' %>
+  <%= link_to 'Back', new_applicants_contract_detail_path(one_year: "yes"), class: 'govuk-back-link' %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/applicants/contract_start_dates/new.html.erb
+++ b/app/views/applicants/contract_start_dates/new.html.erb
@@ -1,5 +1,9 @@
 <% content_for :back_link do %>
-  <%= link_to 'Back', new_applicants_contract_detail_path(one_year: "yes"), class: 'govuk-back-link' %>
+  <% if current_application.application_route == "teacher" %>
+    <%= link_to 'Back', new_applicants_contract_detail_path(one_year: "yes"), class: 'govuk-back-link' %>
+  <% else %>
+    <%= link_to 'Back', new_applicants_salaried_course_detail_path(eligible_course: "yes"), class: 'govuk-back-link' %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/applicants/employment_details/new.html.erb
+++ b/app/views/applicants/employment_details/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :back_link do %>
+  <%= link_to 'Back', new_applicants_personal_detail_path, class: 'govuk-back-link' %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @employment_detail, local: true) do |f| %>

--- a/app/views/applicants/entry_dates/new.html.erb
+++ b/app/views/applicants/entry_dates/new.html.erb
@@ -1,3 +1,6 @@
+<% content_for :back_link do %>
+  <%= link_to 'Back', new_applicants_visa_path, class: 'govuk-back-link' %>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @entry_date, local: true) do |f| %>

--- a/app/views/applicants/personal_details/new.html.erb
+++ b/app/views/applicants/personal_details/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :back_link do %>
+  <%= link_to 'Back', new_applicants_entry_date_path, class: 'govuk-back-link' %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @personal_detail, local: true) do |f| %>

--- a/app/views/applicants/personal_details/new.html.erb
+++ b/app/views/applicants/personal_details/new.html.erb
@@ -28,7 +28,7 @@
         <%= f.govuk_text_field :postcode, label: { text: t("applicants.personal_details.postcode"), size: "s"} %>
       <% end %>
 
-      <%= f.govuk_select(:nationality, NATIONALITIES, label: { text: t("applicants.personal_details.nationality") , size: "s" }) %>
+      <%= f.govuk_select(:nationality, NATIONALITIES.dup.unshift(nil), label: { text: t("applicants.personal_details.nationality") , size: "s" }) %>
 
       <%= f.govuk_radio_buttons_fieldset(:sex, legend: { text: t("applicants.personal_details.sex"), size: "s" }) do %>
         <% Applicants::PersonalDetail::SEX_OPTIONS.each_with_index do |value, i| %>

--- a/app/views/applicants/personal_details/new.html.erb
+++ b/app/views/applicants/personal_details/new.html.erb
@@ -28,7 +28,7 @@
         <%= f.govuk_text_field :postcode, label: { text: t("applicants.personal_details.postcode"), size: "s"} %>
       <% end %>
 
-      <%= f.govuk_select(:nationality, nationality_options, label: { text: t("applicants.personal_details.nationality") , size: "s" }) %>
+      <%= f.govuk_select(:nationality, NATIONALITIES, label: { text: t("applicants.personal_details.nationality") , size: "s" }) %>
 
       <%= f.govuk_radio_buttons_fieldset(:sex, legend: { text: t("applicants.personal_details.sex"), size: "s" }) do %>
         <% Applicants::PersonalDetail::SEX_OPTIONS.each_with_index do |value, i| %>

--- a/app/views/applicants/salaried_course_details/new.html.erb
+++ b/app/views/applicants/salaried_course_details/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :back_link do %>
+  <%= link_to 'Back', new_applicants_application_route_path(application_route: current_application.application_route), class: 'govuk-back-link' %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @salaried_course_detail, local: true) do |f| %>

--- a/app/views/applicants/school_details/new.html.erb
+++ b/app/views/applicants/school_details/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :back_link do %>
+  <%= link_to 'Back', new_applicants_application_route_path(application_route: current_application.application_route), class: 'govuk-back-link' %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @school_detail, local: true) do |f| %>
@@ -7,7 +11,7 @@
         :state_funded_secondary_school,
         legend: { text: t("applicants.school_details.title"), tag: "h1", size: "l" },
         hint: { text: t("applicants.school_details.hint") }
-        ) do %>
+      ) do %>
         <% Applicants::SchoolDetail::SCHOOL_OPTIONS.each_with_index do |value, i| %>
           <%= f.govuk_radio_button :state_funded_secondary_school, value, label: { text: value.humanize }, link_errors: i.zero? %>
         <% end %>

--- a/app/views/applicants/subjects/new.html.erb
+++ b/app/views/applicants/subjects/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :back_link do %>
+  <%= link_to 'Back', new_applicants_contract_start_date_path, class: 'govuk-back-link' %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @subject, local: true) do |f| %>

--- a/app/views/applicants/visas/new.html.erb
+++ b/app/views/applicants/visas/new.html.erb
@@ -1,3 +1,6 @@
+<% content_for :back_link do %>
+  <%= link_to 'Back', new_applicants_subject_path, class: 'govuk-back-link' %>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @visa, local: true) do |f| %>

--- a/app/views/applicants/visas/new.html.erb
+++ b/app/views/applicants/visas/new.html.erb
@@ -8,11 +8,11 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_select(
-        :visa_type,
-        visa_options,
-        label: { text: t("applicants.visa.title"), tag: "h1", size: "l" },
-        include_blank: true
-        )%>
+            :visa_type,
+            Applicants::Visa::VISA_OPTIONS,
+            label: { text: t("applicants.visa.title"), tag: "h1", size: "l" },
+            include_blank: true
+          ) %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/applicants/visas/new.html.erb
+++ b/app/views/applicants/visas/new.html.erb
@@ -9,7 +9,7 @@
 
       <%= f.govuk_select(
             :visa_type,
-            Applicants::Visa::VISA_OPTIONS,
+            Applicants::Visa::VISA_OPTIONS.dup.unshift(nil),
             label: { text: t("applicants.visa.title"), tag: "h1", size: "l" },
             include_blank: true
           ) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,9 @@
       <div class="govuk-width-container">
         <%= yield :breadcrumbs %>
       </div>
+      <% if content_for?(:back_link) %>
+        <%= yield :back_link %>
+      <% end %>
 
       <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
         <%= yield %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,16 +11,16 @@ Rails.application.routes.draw do
 
   namespace :applicants do
     resources :application_routes, only: %i[new create]
-    resources :school_details, only: %i[new create]
-    resources :contract_details, only: %i[new create]
-    resources :contract_start_dates, only: %i[new create]
-    resources :subjects, only: %i[new create]
-    resources :teaching_details, only: %i[new create]
-    resources :visas, only: %i[new create]
-    resources :entry_dates, only: %i[new create]
-    resources :personal_details, only: %i[new create]
-    resources :employment_details, only: %i[new create]
-    resources :salaried_course_details, only: %i[new create]
+    resources :school_details, only: %i[new create edit]
+    resources :contract_details, only: %i[new create edit]
+    resources :contract_start_dates, only: %i[new create edit]
+    resources :subjects, only: %i[new create edit]
+    resources :teaching_details, only: %i[new create edit]
+    resources :visas, only: %i[new create edit]
+    resources :entry_dates, only: %i[new create edit]
+    resources :personal_details, only: %i[new create edit]
+    resources :employment_details, only: %i[new create edit]
+    resources :salaried_course_details, only: %i[new create edit]
     resource :submission, only: %i[show]
   end
 

--- a/spec/controllers/applicants/submissions_controller_spec.rb
+++ b/spec/controllers/applicants/submissions_controller_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+module Applicants
+  RSpec.describe SubmissionsController do
+    describe "GET #show" do
+      let(:application) { create(:application) }
+
+      before do
+        allow(controller).to receive(:current_application).and_return(application)
+      end
+
+      it "resets the session's application_id to nil" do
+        session[:application_id] = 123
+
+        get :show
+
+        expect(session[:application_id]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -43,14 +43,22 @@ describe "teacher route: completing the form" do
   end
 
   def and_i_complete_the_state_school_question
-    expect(page).to have_text(I18n.t("applicants.school_details.title"))
+    assert_i_am_in_the_state_school_question
 
     choose_yes
   end
 
   def and_i_complete_the_contract_details_question
-    expect(page).to have_text(I18n.t("applicants.contract_details.title"))
+    assert_i_am_on_the_contract_details_question
 
     choose_yes
+  end
+
+  def assert_i_am_in_the_state_school_question
+    expect(page).to have_text(I18n.t("applicants.school_details.title"))
+  end
+
+  def assert_i_am_on_the_contract_details_question
+    expect(page).to have_text(I18n.t("applicants.contract_details.title"))
   end
 end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -12,9 +12,9 @@ describe "teacher route: completing the form" do
       and_i_complete_the_state_school_question
       and_i_complete_the_contract_details_question
       and_i_enter_my_contract_start_date
-      and_i_select_my_subject
+      and_i_select_my_subject("teacher")
       and_i_select_my_visa_type
-      and_i_enter_my_entry_date
+      and_i_enter_my_entry_date("teacher")
       and_i_enter_my_personal_details
       and_i_enter_my_employment_details
 
@@ -43,10 +43,14 @@ describe "teacher route: completing the form" do
   end
 
   def and_i_complete_the_state_school_question
+    expect(page).to have_text(I18n.t("applicants.school_details.title"))
+
     choose_yes
   end
 
   def and_i_complete_the_contract_details_question
+    expect(page).to have_text(I18n.t("applicants.contract_details.title"))
+
     choose_yes
   end
 end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -76,4 +76,10 @@ describe "teacher route: completing the form" do
       assert_i_am_in_the_application_route_question
     end
   end
+
+  describe "navigating backwards, then forward" do
+    it "allows the user to navigate back & forth from the first question" do
+      skip "This needs persistence of the first questions"
+    end
+  end
 end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -48,6 +48,8 @@ describe "teacher route: completing the form" do
       and_i_enter_my_entry_date("teacher")
       and_i_enter_my_personal_details
 
+      # We're now on the employment details page
+      # We start going backwards
       when_i_click_the_back_link
       assert_i_am_in_the_personal_details_question
 

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -35,32 +35,4 @@ describe "teacher route: completing the form" do
       end
     end
   end
-
-  def and_i_enter_an_invalid_date
-    fill_in("Day", with: 31)
-    fill_in("Month", with: 2)
-    fill_in("Year", with: 2019)
-
-    click_button("Continue")
-  end
-
-  def and_i_complete_the_state_school_question
-    assert_i_am_in_the_state_school_question
-
-    choose_yes
-  end
-
-  def and_i_complete_the_contract_details_question
-    assert_i_am_on_the_contract_details_question
-
-    choose_yes
-  end
-
-  def assert_i_am_in_the_state_school_question
-    expect(page).to have_text(I18n.t("applicants.school_details.title"))
-  end
-
-  def assert_i_am_on_the_contract_details_question
-    expect(page).to have_text(I18n.t("applicants.contract_details.title"))
-  end
 end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe "teacher route: completing the form" do
   include_context "with common application form steps"
+  include_context "with common application form assertions"
 
   describe "navigating forward" do
     context "eligible users" do

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -35,4 +35,42 @@ describe "teacher route: completing the form" do
       end
     end
   end
+
+  describe "navigating backwards" do
+    it "allows the user to navigate back to the previous pages" do
+      when_i_start_the_form
+      and_i_complete_application_route_question_with(option: "teacher")
+      and_i_complete_the_state_school_question
+      and_i_complete_the_contract_details_question
+      and_i_enter_my_contract_start_date
+      and_i_select_my_subject("teacher")
+      and_i_select_my_visa_type
+      and_i_enter_my_entry_date("teacher")
+      and_i_enter_my_personal_details
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_personal_details_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_entry_date_question("teacher")
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_visa_type_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_subject_question("teacher")
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_contract_start_date_question
+
+      when_i_click_the_back_link
+      assert_i_am_on_the_contract_details_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_state_school_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_application_route_question
+    end
+  end
 end

--- a/spec/features/teacher_route_completing_the_form_spec.rb
+++ b/spec/features/teacher_route_completing_the_form_spec.rb
@@ -5,41 +5,43 @@ require "rails_helper"
 describe "teacher route: completing the form" do
   include_context "with common application form steps"
 
-  context "with no eligibility failures" do
-    it "submits an application" do
-      when_i_start_the_form
-      and_i_complete_application_route_question_with(option: "teacher")
-      and_i_complete_the_state_school_question
-      and_i_complete_the_contract_details_question
-      and_i_enter_my_contract_start_date
-      and_i_select_my_subject("teacher")
-      and_i_select_my_visa_type
-      and_i_enter_my_entry_date("teacher")
-      and_i_enter_my_personal_details
-      and_i_enter_my_employment_details
+  describe "navigating forward" do
+    context "eligible users" do
+      it "submits an application" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(option: "teacher")
+        and_i_complete_the_state_school_question
+        and_i_complete_the_contract_details_question
+        and_i_enter_my_contract_start_date
+        and_i_select_my_subject("teacher")
+        and_i_select_my_visa_type
+        and_i_enter_my_entry_date("teacher")
+        and_i_enter_my_personal_details
+        and_i_enter_my_employment_details
 
-      then_the_application_is_submitted_successfully
+        then_the_application_is_submitted_successfully
+      end
+    end
+
+    context "non-eligible users" do
+      it "does not allow the user to continue the journey" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(option: "teacher")
+        and_i_complete_the_state_school_question
+        and_i_complete_the_contract_details_question
+        and_i_enter_an_invalid_date
+
+        expect(page).to have_text("Enter a valid date")
+      end
     end
   end
 
-  context "with validation errors" do
-    it "does not allow the user to continue the journey" do
-      when_i_start_the_form
-      and_i_complete_application_route_question_with(option: "teacher")
-      and_i_complete_the_state_school_question
-      and_i_complete_the_contract_details_question
-      and_i_enter_an_invalid_date
+  def and_i_enter_an_invalid_date
+    fill_in("Day", with: 31)
+    fill_in("Month", with: 2)
+    fill_in("Year", with: 2019)
 
-      expect(page).to have_text("Enter a valid date")
-    end
-
-    def and_i_enter_an_invalid_date
-      fill_in("Day", with: 31)
-      fill_in("Month", with: 2)
-      fill_in("Year", with: 2019)
-
-      click_button("Continue")
-    end
+    click_button("Continue")
   end
 
   def and_i_complete_the_state_school_question

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe "trainee route: completing the form" do
   include_context "with common application form steps"
+  include_context "with common application form assertions"
 
   describe "navigating forward" do
     context "eligible users" do

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -91,7 +91,6 @@ describe "trainee route: completing the form" do
       when_i_click_the_back_link
       assert_i_am_in_the_trainee_employment_conditions_question
 
-
       # We start going forward again from the first question
       when_i_click_the_continue_button
       assert_i_am_in_the_contract_start_date_question

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -70,4 +70,39 @@ describe "trainee route: completing the form" do
       assert_i_am_in_the_application_route_question
     end
   end
+
+  describe "navigating backwards, then forward" do
+    it "allows the user to navigate back & forth" do
+      when_i_start_the_form
+      and_i_complete_application_route_question_with(option: "salaried_trainee")
+      and_i_complete_the_trainee_employment_conditions
+      and_i_enter_my_contract_start_date
+      and_i_select_my_subject("salaried_trainee")
+      and_i_select_my_visa_type
+      and_i_enter_my_entry_date("salaried_trainee")
+      and_i_enter_my_personal_details
+
+      # We're now on the employment details page
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      when_i_click_the_back_link
+      assert_i_am_in_the_trainee_employment_conditions_question
+
+
+      # We start going forward again from the first question
+      when_i_click_the_continue_button
+      assert_i_am_in_the_contract_start_date_question
+
+      when_i_click_the_continue_button
+      when_i_click_the_continue_button
+      when_i_click_the_continue_button
+      when_i_click_the_continue_button
+      when_i_click_the_continue_button
+
+      assert_i_am_in_the_employment_details_question
+    end
+  end
 end

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -33,12 +33,4 @@ describe "trainee route: completing the form" do
       end
     end
   end
-
-  def and_i_complete_the_trainee_employment_conditions(choose: "Yes")
-    choose == "Yes" ? choose_yes : choose_no
-  end
-
-  def and_i_complete_the_trainee_contract_details_question
-    choose_yes
-  end
 end

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -24,9 +24,9 @@ describe "trainee route: completing the form" do
       and_i_complete_application_route_question_with(option: "salaried_trainee")
       and_i_complete_the_trainee_employment_conditions
       and_i_enter_my_contract_start_date
-      and_i_select_my_subject
+      and_i_select_my_subject("salaried_trainee")
       and_i_select_my_visa_type
-      and_i_enter_my_entry_date
+      and_i_enter_my_entry_date("salaried_trainee")
       and_i_enter_my_personal_details
       and_i_enter_my_employment_details
 

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -33,4 +33,40 @@ describe "trainee route: completing the form" do
       end
     end
   end
+
+  describe "navigating backwards" do
+    it "allows the user to navigate back to the previous pages" do
+      when_i_start_the_form
+      and_i_complete_application_route_question_with(option: "salaried_trainee")
+      and_i_complete_the_trainee_employment_conditions
+      and_i_enter_my_contract_start_date
+      and_i_select_my_subject("salaried_trainee")
+      and_i_select_my_visa_type
+      and_i_enter_my_entry_date("salaried_trainee")
+      and_i_enter_my_personal_details
+
+      # We're now on the employment details page
+      # We start going backwards
+      when_i_click_the_back_link
+      assert_i_am_in_the_personal_details_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_entry_date_question("salaried_trainee")
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_visa_type_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_subject_question("salaried_trainee")
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_contract_start_date_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_trainee_employment_conditions_question
+
+      when_i_click_the_back_link
+      assert_i_am_in_the_application_route_question
+    end
+  end
 end

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -5,32 +5,32 @@ require "rails_helper"
 describe "trainee route: completing the form" do
   include_context "with common application form steps"
 
-  context "with eligibility failures" do
-    context "when not employed in a school as a trainee teacher" do
-      it "shows custom inelibility page" do
+  describe "navigating forward" do
+    context "eligible users" do
+      it "submits an application" do
+        when_i_start_the_form
+        and_i_complete_application_route_question_with(option: "salaried_trainee")
+        and_i_complete_the_trainee_employment_conditions
+        and_i_enter_my_contract_start_date
+        and_i_select_my_subject("salaried_trainee")
+        and_i_select_my_visa_type
+        and_i_enter_my_entry_date("salaried_trainee")
+        and_i_enter_my_personal_details
+        and_i_enter_my_employment_details
+
+        then_the_application_is_submitted_successfully
+      end
+    end
+
+    context "non-eligible users" do
+      it "shows ineligible page" do
         when_i_start_the_form
         and_i_complete_application_route_question_with(option: "salaried_trainee")
         and_i_complete_the_trainee_employment_conditions(choose: "No")
 
         expect(page).to have_text("We’re sorry")
-                    .and have_text("If you are enrolled on a fee-paying teacher training course")
+                          .and have_text("If you are enrolled on a fee-paying teacher training course")
       end
-    end
-  end
-
-  context "with no eligibility failures" do
-    it "submits an application" do
-      when_i_start_the_form
-      and_i_complete_application_route_question_with(option: "salaried_trainee")
-      and_i_complete_the_trainee_employment_conditions
-      and_i_enter_my_contract_start_date
-      and_i_select_my_subject("salaried_trainee")
-      and_i_select_my_visa_type
-      and_i_enter_my_entry_date("salaried_trainee")
-      and_i_enter_my_personal_details
-      and_i_enter_my_employment_details
-
-      then_the_application_is_submitted_successfully
     end
   end
 

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -30,7 +30,7 @@ module Applicants
       include_examples "a valid UK postcode", described_class
       include_examples "validates phone number with international prefix", described_class, :phone_number
 
-      describe ".load" do
+      describe "#applicant=" do
         let(:applicant) do
           create(:applicant,
                  given_name: "John",
@@ -48,7 +48,7 @@ module Applicants
                                 postcode: "SW1A 1AA"))
         end
 
-        subject(:model) { described_class.load(applicant) }
+        subject(:model) { described_class.new(applicant:) }
 
         it "loads the applicant's personal details" do
           expect(model).to have_attributes(

--- a/spec/models/applicants/personal_detail_spec.rb
+++ b/spec/models/applicants/personal_detail_spec.rb
@@ -30,6 +30,56 @@ module Applicants
       include_examples "a valid UK postcode", described_class
       include_examples "validates phone number with international prefix", described_class, :phone_number
 
+      describe ".load" do
+        let(:applicant) do
+          create(:applicant,
+                 given_name: "John",
+                 family_name: "Smith",
+                 email_address: "john.gmail.com",
+                 phone_number: "07777777777",
+                 date_of_birth: Date.new(2020, 3, 30),
+                 sex: "male",
+                 passport_number: "123456789",
+                 nationality: "Spanish",
+                 address: build(:address,
+                                address_line_1: "1 High Street",
+                                address_line_2: "Flat 1",
+                                city: "London",
+                                postcode: "SW1A 1AA"))
+        end
+
+        subject(:model) { described_class.load(applicant) }
+
+        it "loads the applicant's personal details" do
+          expect(model).to have_attributes(
+            given_name: "John",
+            family_name: "Smith",
+            email_address: "john.gmail.com",
+            phone_number: "07777777777",
+            sex: "male",
+            passport_number: "123456789",
+            nationality: "Spanish",
+          )
+        end
+
+        it "loads the applicant's date of birth" do
+          expect(model).to have_attributes(
+            day: 30,
+            month: 3,
+            year: 2020,
+          )
+        end
+
+        it "loads the applicant's address" do
+          expect(model).to have_attributes(
+            address_line_1: "1 High Street",
+            address_line_2: "Flat 1",
+            city: "London",
+            postcode: "SW1A 1AA",
+          )
+        end
+      end
+
       describe "save!" do
         let(:params) do
           {

--- a/spec/support/application_form_assertions.rb
+++ b/spec/support/application_form_assertions.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with common application form assertions" do
+  def assert_i_am_in_the_subject_question(route)
+    expect(page).to have_text(I18n.t("applicants.subjects.title.#{route}"))
+  end
+
+  def assert_i_am_in_the_contract_start_date_question
+    expect(page).to have_text(I18n.t("applicants.contract_start_dates.title"))
+  end
+
+  def assert_i_am_in_the_employment_details_question
+    expect(page).to have_text(I18n.t("applicants.employment_details.title"))
+  end
+
+  def assert_i_am_in_the_personal_details_question
+    expect(page).to have_text(I18n.t("applicants.personal_details.title"))
+  end
+
+  def assert_i_am_in_the_entry_date_question(route)
+    expect(page).to have_text(I18n.t("applicants.entry_dates.title.#{route}"))
+  end
+
+  def assert_i_am_in_the_visa_type_question
+    expect(page).to have_text(I18n.t("applicants.visa.title"))
+  end
+
+  def assert_i_am_in_the_application_route_question
+    expect(page).to have_text(I18n.t("applicants.application_routes.title"))
+  end
+
+  def assert_i_am_in_the_trainee_employment_conditions_question
+    expect(page).to have_text(I18n.t("applicants.salaried_course.title"))
+  end
+
+  def and_i_complete_the_state_school_question
+    assert_i_am_in_the_state_school_question
+
+    choose_yes
+  end
+
+  def and_i_complete_the_contract_details_question
+    assert_i_am_on_the_contract_details_question
+
+    choose_yes
+  end
+
+  def assert_i_am_in_the_state_school_question
+    expect(page).to have_text(I18n.t("applicants.school_details.title"))
+  end
+
+  def assert_i_am_on_the_contract_details_question
+    expect(page).to have_text(I18n.t("applicants.contract_details.title"))
+  end
+end

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -26,21 +26,24 @@ RSpec.shared_context "with common application form steps" do
   end
 
   def and_i_select_my_subject(route)
-    expect(page).to have_text(I18n.t("applicants.subjects.title.#{route}"))
+    assert_i_am_in_the_subject_question(route)
+
     choose("Physics")
 
     click_button("Continue")
   end
 
   def and_i_select_my_visa_type
-    expect(page).to have_text(I18n.t("applicants.visa.title"))
+    assert_i_am_in_the_visa_type_question
+
     select("Family visa")
 
     click_button("Continue")
   end
 
   def and_i_enter_my_entry_date(route)
-    expect(page).to have_text(I18n.t("applicants.entry_dates.title.#{route}"))
+    assert_i_am_in_the_entry_date_question(route)
+
     fill_in("Day", with: 12)
     fill_in("Month", with: 6)
     fill_in("Year", with: 2023)
@@ -49,7 +52,7 @@ RSpec.shared_context "with common application form steps" do
   end
 
   def and_i_enter_my_personal_details
-    expect(page).to have_text(I18n.t("applicants.personal_details.title"))
+    assert_i_am_in_the_personal_details_question
 
     fill_in("applicants_personal_detail[given_name]", with: "Bob")
     fill_in("applicants_personal_detail[family_name]", with: "Robertson")
@@ -71,7 +74,7 @@ RSpec.shared_context "with common application form steps" do
   end
 
   def and_i_enter_my_employment_details
-    expect(page).to have_text(I18n.t("applicants.employment_details.title"))
+    assert_i_am_in_the_employment_details_question
 
     fill_in("applicants_employment_detail[school_headteacher_name]", with: "Mr Headteacher")
     fill_in("applicants_employment_detail[school_name]", with: "School name")
@@ -96,12 +99,36 @@ RSpec.shared_context "with common application form steps" do
   end
 
   def and_i_enter_my_contract_start_date
-    expect(page).to have_text(I18n.t("applicants.contract_start_dates.title"))
+    assert_i_am_in_the_contract_start_date_question
 
     fill_in("Day", with: 12)
     fill_in("Month", with: 7)
     fill_in("Year", with: 2023)
 
     click_button("Continue")
+  end
+
+  def assert_i_am_in_the_subject_question(route)
+    expect(page).to have_text(I18n.t("applicants.subjects.title.#{route}"))
+  end
+
+  def assert_i_am_in_the_contract_start_date_question
+    expect(page).to have_text(I18n.t("applicants.contract_start_dates.title"))
+  end
+
+  def assert_i_am_in_the_employment_details_question
+    expect(page).to have_text(I18n.t("applicants.employment_details.title"))
+  end
+
+  def assert_i_am_in_the_personal_details_question
+    expect(page).to have_text(I18n.t("applicants.personal_details.title"))
+  end
+
+  def assert_i_am_in_the_entry_date_question(route)
+    expect(page).to have_text(I18n.t("applicants.entry_dates.title.#{route}"))
+  end
+
+  def assert_i_am_in_the_visa_type_question
+    expect(page).to have_text(I18n.t("applicants.visa.title"))
   end
 end

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -131,4 +131,40 @@ RSpec.shared_context "with common application form steps" do
   def assert_i_am_in_the_visa_type_question
     expect(page).to have_text(I18n.t("applicants.visa.title"))
   end
+
+  def and_i_complete_the_trainee_employment_conditions(choose: "Yes")
+    choose == "Yes" ? choose_yes : choose_no
+  end
+
+  def and_i_complete_the_trainee_contract_details_question
+    choose_yes
+  end
+
+  def and_i_enter_an_invalid_date
+    fill_in("Day", with: 31)
+    fill_in("Month", with: 2)
+    fill_in("Year", with: 2019)
+
+    click_button("Continue")
+  end
+
+  def and_i_complete_the_state_school_question
+    assert_i_am_in_the_state_school_question
+
+    choose_yes
+  end
+
+  def and_i_complete_the_contract_details_question
+    assert_i_am_on_the_contract_details_question
+
+    choose_yes
+  end
+
+  def assert_i_am_in_the_state_school_question
+    expect(page).to have_text(I18n.t("applicants.school_details.title"))
+  end
+
+  def assert_i_am_on_the_contract_details_question
+    expect(page).to have_text(I18n.t("applicants.contract_details.title"))
+  end
 end

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -21,6 +21,10 @@ RSpec.shared_context "with common application form steps" do
     click_link("Back")
   end
 
+  def when_i_click_the_continue_button
+    click_button("Continue")
+  end
+
   def and_i_complete_application_route_question_with(option:)
     raise "Unexpected option: #{option}" unless %w[salaried_trainee teacher].include?(option)
 
@@ -113,6 +117,8 @@ RSpec.shared_context "with common application form steps" do
   end
 
   def and_i_complete_the_trainee_employment_conditions(choose: "Yes")
+    assert_i_am_in_the_trainee_employment_conditions_question
+
     choose == "Yes" ? choose_yes : choose_no
   end
 

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -17,6 +17,10 @@ RSpec.shared_context "with common application form steps" do
     click_link("Start")
   end
 
+  def when_i_click_the_back_link
+    click_link("Back")
+  end
+
   def and_i_complete_application_route_question_with(option:)
     raise "Unexpected option: #{option}" unless %w[salaried_trainee teacher].include?(option)
 
@@ -130,6 +134,10 @@ RSpec.shared_context "with common application form steps" do
 
   def assert_i_am_in_the_visa_type_question
     expect(page).to have_text(I18n.t("applicants.visa.title"))
+  end
+
+  def assert_i_am_in_the_application_route_question
+    expect(page).to have_text(I18n.t("applicants.application_routes.title"))
   end
 
   def and_i_complete_the_trainee_employment_conditions(choose: "Yes")

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -112,38 +112,6 @@ RSpec.shared_context "with common application form steps" do
     click_button("Continue")
   end
 
-  def assert_i_am_in_the_subject_question(route)
-    expect(page).to have_text(I18n.t("applicants.subjects.title.#{route}"))
-  end
-
-  def assert_i_am_in_the_contract_start_date_question
-    expect(page).to have_text(I18n.t("applicants.contract_start_dates.title"))
-  end
-
-  def assert_i_am_in_the_employment_details_question
-    expect(page).to have_text(I18n.t("applicants.employment_details.title"))
-  end
-
-  def assert_i_am_in_the_personal_details_question
-    expect(page).to have_text(I18n.t("applicants.personal_details.title"))
-  end
-
-  def assert_i_am_in_the_entry_date_question(route)
-    expect(page).to have_text(I18n.t("applicants.entry_dates.title.#{route}"))
-  end
-
-  def assert_i_am_in_the_visa_type_question
-    expect(page).to have_text(I18n.t("applicants.visa.title"))
-  end
-
-  def assert_i_am_in_the_application_route_question
-    expect(page).to have_text(I18n.t("applicants.application_routes.title"))
-  end
-
-  def assert_i_am_in_the_trainee_employment_conditions_question
-    expect(page).to have_text(I18n.t("applicants.salaried_course.title"))
-  end
-
   def and_i_complete_the_trainee_employment_conditions(choose: "Yes")
     choose == "Yes" ? choose_yes : choose_no
   end
@@ -158,25 +126,5 @@ RSpec.shared_context "with common application form steps" do
     fill_in("Year", with: 2019)
 
     click_button("Continue")
-  end
-
-  def and_i_complete_the_state_school_question
-    assert_i_am_in_the_state_school_question
-
-    choose_yes
-  end
-
-  def and_i_complete_the_contract_details_question
-    assert_i_am_on_the_contract_details_question
-
-    choose_yes
-  end
-
-  def assert_i_am_in_the_state_school_question
-    expect(page).to have_text(I18n.t("applicants.school_details.title"))
-  end
-
-  def assert_i_am_on_the_contract_details_question
-    expect(page).to have_text(I18n.t("applicants.contract_details.title"))
   end
 end

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -140,6 +140,10 @@ RSpec.shared_context "with common application form steps" do
     expect(page).to have_text(I18n.t("applicants.application_routes.title"))
   end
 
+  def assert_i_am_in_the_trainee_employment_conditions_question
+    expect(page).to have_text(I18n.t("applicants.salaried_course.title"))
+  end
+
   def and_i_complete_the_trainee_employment_conditions(choose: "Yes")
     choose == "Yes" ? choose_yes : choose_no
   end

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -25,19 +25,22 @@ RSpec.shared_context "with common application form steps" do
     click_button("Continue")
   end
 
-  def and_i_select_my_subject
+  def and_i_select_my_subject(route)
+    expect(page).to have_text(I18n.t("applicants.subjects.title.#{route}"))
     choose("Physics")
 
     click_button("Continue")
   end
 
   def and_i_select_my_visa_type
+    expect(page).to have_text(I18n.t("applicants.visa.title"))
     select("Family visa")
 
     click_button("Continue")
   end
 
-  def and_i_enter_my_entry_date
+  def and_i_enter_my_entry_date(route)
+    expect(page).to have_text(I18n.t("applicants.entry_dates.title.#{route}"))
     fill_in("Day", with: 12)
     fill_in("Month", with: 6)
     fill_in("Year", with: 2023)
@@ -46,6 +49,8 @@ RSpec.shared_context "with common application form steps" do
   end
 
   def and_i_enter_my_personal_details
+    expect(page).to have_text(I18n.t("applicants.personal_details.title"))
+
     fill_in("applicants_personal_detail[given_name]", with: "Bob")
     fill_in("applicants_personal_detail[family_name]", with: "Robertson")
     fill_in("applicants_personal_detail[email_address]", with: "test@example.com")
@@ -66,6 +71,8 @@ RSpec.shared_context "with common application form steps" do
   end
 
   def and_i_enter_my_employment_details
+    expect(page).to have_text(I18n.t("applicants.employment_details.title"))
+
     fill_in("applicants_employment_detail[school_headteacher_name]", with: "Mr Headteacher")
     fill_in("applicants_employment_detail[school_name]", with: "School name")
     fill_in("applicants_employment_detail[school_address_line_1]", with: "1, McSchool Street")
@@ -89,6 +96,8 @@ RSpec.shared_context "with common application form steps" do
   end
 
   def and_i_enter_my_contract_start_date
+    expect(page).to have_text(I18n.t("applicants.contract_start_dates.title"))
+
     fill_in("Day", with: 12)
     fill_in("Month", with: 7)
     fill_in("Year", with: 2023)


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/jF2pkWBA/76-enable-back-forward-navigation-according-to-govuk-guidelines

### Description

Introduces navigation back from any question in the Applicant's journey:

1. A user is able to navigate backwards from the School details to the first question of the Journey. Both for the trainee and the teacher application routes.
2. When navigating backwards it persists all the information entered by the applicant: Dates, personal details and individual questions.
3. When an application is submitted, the user can't go back and resubmit the same application. It is redirected to the Start page.

![image](https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/134513241/1db61df6-fef0-4751-a85a-0d2c5d4962ec)

### Technical notes

1. [In the first commits](6ec16bbb697c6a1f67f544dfd980e252bc5a625b) I am updating our system tests to make sure that we are in the right page. This has been updated for Trainee and Teacher routes.
2. It includes tests to ensure that backward navigation is working.

### Pending

1. Make sure that a user can go back to the first question, and then progress in the Teacher route. With the current implementation, the application would need to answer yes to the first question. This is currently no implemented as we would need to persist every single question. As a side note, all the other information is properly stored.


