### PR TITLE
Export CSV: payroll

### DIFF
--- a/app/controllers/system_admin/reports_controller.rb
+++ b/app/controllers/system_admin/reports_controller.rb
@@ -14,6 +14,7 @@ module SystemAdmin
       {
         home_office: Reports::HomeOffice.new,
         standing_data: Reports::StandingData.new,
+        payroll: Reports::Payroll.new,
       }.with_indifferent_access.fetch(report_id)
     end
   end

--- a/app/models/reports/payroll.rb
+++ b/app/models/reports/payroll.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Reports
+  class Payroll
+    def name
+      "Payroll-Report.csv"
+    end
+
+    def csv
+      CSV.generate do |csv|
+        csv << header
+        rows.each { |row| csv << row }
+      end
+    end
+
+  private
+
+    def rows
+      candidates.pluck(
+        "urn",
+        "given_name",
+        "family_name",
+        "date_of_birth",
+        "sex",
+        "email_address",
+        "address_line_1",
+        "postcode",
+        "phone_number",
+      )
+    end
+
+    def candidates
+      Application
+        .joins(:application_progress)
+        .joins(applicant: :address)
+        .where.not(application_progresses: { banking_approval_completed_at: nil })
+    end
+
+    def header
+      %w[
+        URN
+        Forename
+        Surname
+        DOB
+        Gender
+        Email
+        Address
+        Postcode
+        Telephone
+      ]
+    end
+  end
+end

--- a/app/models/reports/payroll.rb
+++ b/app/models/reports/payroll.rb
@@ -3,7 +3,9 @@
 module Reports
   class Payroll
     def name
-      "Payroll-Report.csv"
+      current_time = Time.zone.now.strftime("%Y%m%d-%H%M%S")
+
+      "Payroll-Report-#{current_time}.csv"
     end
 
     def csv

--- a/app/views/system_admin/reports/index.html.erb
+++ b/app/views/system_admin/reports/index.html.erb
@@ -15,5 +15,13 @@
   </p>
 </div>
 
+<div class="payroll">
+  <h2 class="govuk-heading-m">Payroll Data report</h2>
+  <p class="govuk-body">Downloads a CSV with the applicants with banking details approved</p>
+  <p>
+    <%= link_to "Download", report_path(:payroll), class: "govuk-button" %>
+  </p>
+</div>
+
 
 

--- a/spec/features/admin_console/reports_spec.rb
+++ b/spec/features/admin_console/reports_spec.rb
@@ -46,7 +46,7 @@ private
   def then_the_payroll_data_csv_report_is_downloaded
     expect(page.response_headers["Content-Type"]).to match(/text\/csv/)
     expect(page.response_headers["Content-Disposition"]).to include "attachment"
-    expect(page.response_headers["Content-Disposition"]).to include 'filename="Payroll-Report.csv"'
+    expect(page.response_headers["Content-Disposition"]).to match(/filename="Payroll-Report.*/)
   end
 
   def and_i_click_on_the_home_office_csv_link

--- a/spec/features/admin_console/reports_spec.rb
+++ b/spec/features/admin_console/reports_spec.rb
@@ -21,6 +21,14 @@ describe "Reports - export to CSV" do
     then_the_standing_data_csv_report_is_downloaded
   end
 
+  it "exports Payroll Data CSV" do
+    given_i_am_signed_as_an_admin
+    when_i_am_in_the_reports_page
+    and_i_click_on_the_payroll_data_csv_link
+
+    then_the_payroll_data_csv_report_is_downloaded
+  end
+
 private
 
   def then_the_standing_data_csv_report_is_downloaded
@@ -35,6 +43,12 @@ private
     expect(page.response_headers["Content-Disposition"]).to match(/filename="Home-Office-Report.*/)
   end
 
+  def then_the_payroll_data_csv_report_is_downloaded
+    expect(page.response_headers["Content-Type"]).to match(/text\/csv/)
+    expect(page.response_headers["Content-Disposition"]).to include "attachment"
+    expect(page.response_headers["Content-Disposition"]).to include 'filename="Payroll-Report.csv"'
+  end
+
   def and_i_click_on_the_home_office_csv_link
     within ".home-office" do
       click_on "Download"
@@ -43,6 +57,12 @@ private
 
   def and_i_click_on_the_standing_data_csv_link
     within ".standing-data" do
+      click_on "Download"
+    end
+  end
+
+  def and_i_click_on_the_payroll_data_csv_link
+    within ".payroll" do
       click_on "Download"
     end
   end

--- a/spec/models/reports/payroll_spec.rb
+++ b/spec/models/reports/payroll_spec.rb
@@ -5,10 +5,20 @@ require "rails_helper"
 # rubocop:disable Metrics/ExampleLength
 module Reports
   describe Payroll do
+    include ActiveSupport::Testing::TimeHelpers
+
     subject(:report) { described_class.new }
 
     it "returns the name of the Report" do
-      expect(report.name).to eq("Payroll-Report.csv")
+      frozen_time = Time.zone.local(2023, 7, 17, 12, 30, 45)
+      travel_to frozen_time do
+        expected_name = "Payroll-Report-20230717-123045.csv"
+
+        report = described_class.new
+        actual_name = report.name
+
+        expect(actual_name).to eq(expected_name)
+      end
     end
 
     describe "#csv" do

--- a/spec/models/reports/payroll_spec.rb
+++ b/spec/models/reports/payroll_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable Metrics/ExampleLength
+module Reports
+  describe Payroll do
+    subject(:report) { described_class.new }
+
+    it "returns the name of the Report" do
+      expect(report.name).to eq("Payroll-Report.csv")
+    end
+
+    describe "#csv" do
+      let(:progress) { build(:application_progress, banking_approval_completed_at: Time.zone.now) }
+
+      it "returns applicants who have banking details approved" do
+        app = create(:application, application_progress: progress)
+
+        expect(report.csv).to include(app.urn)
+      end
+
+      it "does not return applicants who have not the bankind details approved" do
+        progress.banking_approval_completed_at = nil
+        app = create(:application, application_progress: progress)
+
+        expect(report.csv).not_to include(app.urn)
+      end
+
+      it "returns the data in CSV format" do
+        application = create(:application, application_progress: progress)
+
+        expect(report.csv).to include([
+          application.urn,
+          application.applicant.given_name,
+          application.applicant.family_name,
+          application.applicant.date_of_birth,
+          application.applicant.sex,
+          application.applicant.email_address,
+          application.applicant.address.address_line_1,
+          application.applicant.address.postcode,
+          application.applicant.phone_number,
+        ].join(","))
+      end
+
+      it "returns the header in CSV format" do
+        expected_header = %w[
+          URN
+          Forename
+          Surname
+          DOB
+          Gender
+          Email
+          Address
+          Postcode
+          Telephone
+        ].join(",")
+
+        expect(report.csv).to include(expected_header)
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/ExampleLength


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/NMAhMvxu/128-service-settings-download-csv-for-payroll

## Description

Following work on #144. and #145 , we are including a new report: `Payroll Report`, which 
returns the following fields:

```ruby
%w[
  URN
  Forename
  Surname
  DOB
  Gender
  Email
  Address
  Postcode
  Telephone
]
```

It will list only applicants with baking details approved.

### Screenshots

<img width="971" alt="image" src="https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/134513241/3c18e7e8-d95c-4853-ac3e-4b668060fb70">

