### PR TITLE
Disable all web crawlers for pen-testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 A service to collect details from teachers and trainees applying for the
 International Relocation Payment.
 
+## Robots.txt
+
+A robots.txt file is located at `public/robots.txt` and prevents all robots from
+crawling the site. This is to prevent the site from being indexed by search engines
+while we are doing pen-testing in production for 2 days.
+
+We should remove the lines below before moving to production.
+
+```txt
+User-agent: *
+Disallow: /
+```
+
 ## Development
 
 ### Install build dependencies

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,3 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/hc45OQs6/145-disallow-web-crawlers-and-robots-to-crawl-the-site

## Description

Updates the robots.txt file to disallow access to all directories and
files ("/") for all web crawlers ("User-agent: *"). This ensures that all web
crawlers are prevented from crawling and indexing any pages on the website,
effectively blocking it from search engine results.

```txt
User-agent: *
Disallow: /
```


