### PR TITLE
Remove start service date from service closed page

### DIFF
--- a/app/views/pages/closed.html.erb
+++ b/app/views/pages/closed.html.erb
@@ -11,9 +11,6 @@
     <p class="govuk-body">
       The IRP application window is currently closed.
     </p>
-    <p class="govuk-body">
-      The next application window opens: (insert the next window opening)
-    </p>
 
     <h2 class="govuk-heading-m">When to apply for the IRP</h2>
 


### PR DESCRIPTION
## Trello Card Link

- https://trello.com/c/aEqooIHr/129-service-settings-add-a-toggle-to-open-close-applications-service
- https://trello.com/c/KBaRff09/89-application-window-closed-page

## Description

We have decided to remove the start date from the application close page.