### PR TITLE
Remove rejected applicants from HomeOffice report

### DIFF
--- a/app/models/reports/home_office.rb
+++ b/app/models/reports/home_office.rb
@@ -34,7 +34,10 @@ module Reports
         .joins(:application_progress)
         .joins(:applicant)
         .where.not(application_progresses: { initial_checks_completed_at: nil })
-        .where(application_progresses: { home_office_checks_completed_at: nil })
+        .where(application_progresses: {
+          home_office_checks_completed_at: nil,
+          rejection_completed_at: nil,
+        })
     end
 
     def header

--- a/spec/models/reports/home_office_spec.rb
+++ b/spec/models/reports/home_office_spec.rb
@@ -28,6 +28,15 @@ module Reports
         expect(report.csv).to include(app.urn)
       end
 
+      it "does not return rejected applicants" do
+        progress = build(:application_progress,
+                         :home_office_pending,
+                         rejection_completed_at: Time.zone.now)
+        app = create(:application, application_progress: progress)
+
+        expect(report.csv).not_to include(app.urn)
+      end
+
       it "does not return applicants who have not completed initial checks" do
         app = create(:application, application_progress: build(:application_progress, initial_checks_completed_at: nil))
 


### PR DESCRIPTION
## Trello Card Link

https://trello.com/c/ZHLorhH6/126-service-settings-download-csv-for-ho

## Description

Do not include Rejected applicants in Home Office report.
