### PR TITLE
Fix duplicates error

### DIFF
--- a/db/migrate/20230816100957_update_duplicate_applications_to_version_2.rb
+++ b/db/migrate/20230816100957_update_duplicate_applications_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateDuplicateApplicationsToVersion2 < ActiveRecord::Migration[7.0]
+  def change
+    update_view :duplicate_applications, version: 2, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_14_222343) do
+ActiveRecord::Schema[7.0].define(version: 20_230_816_100_957) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_222343) do
              FROM applicants applicants_1
             GROUP BY applicants_1.email_address
            HAVING (count(applicants_1.email_address) > 1)) dup_email ON ((applicants.email_address = dup_email.email_address)))
+    WHERE (applications.urn IS NOT NULL)
   UNION
    SELECT applications.id,
       applications.application_date,
@@ -144,6 +145,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_222343) do
              FROM applicants applicants_1
             GROUP BY applicants_1.phone_number
            HAVING (count(applicants_1.phone_number) > 1)) dup_phone ON ((applicants.phone_number = dup_phone.phone_number)))
+    WHERE (applications.urn IS NOT NULL)
   UNION
    SELECT applications.id,
       applications.application_date,
@@ -163,6 +165,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_222343) do
               count(applicants_1.passport_number) AS count
              FROM applicants applicants_1
             GROUP BY applicants_1.passport_number
-           HAVING (count(applicants_1.passport_number) > 1)) dup_passport ON ((applicants.passport_number = dup_passport.passport_number)));
+           HAVING (count(applicants_1.passport_number) > 1)) dup_passport ON ((applicants.passport_number = dup_passport.passport_number)))
+    WHERE (applications.urn IS NOT NULL);
   SQL
 end

--- a/db/views/duplicate_applications_v02.sql
+++ b/db/views/duplicate_applications_v02.sql
@@ -1,0 +1,81 @@
+SELECT 
+  applications.*,
+  dup_email.email_address AS duplicate_email
+FROM
+  applications
+INNER JOIN 
+  applicants
+ON
+  applications.applicant_id = applicants.id
+INNER JOIN 
+  (
+    SELECT 
+      email_address,
+      COUNT(email_address)
+    FROM 
+      applicants 
+    GROUP BY 
+      email_address
+    HAVING 
+      COUNT(email_address) > 1
+  ) dup_email 
+ON 
+  applicants.email_address = dup_email.email_address
+WHERE 
+  applications.urn IS NOT NULL
+
+UNION
+
+SELECT 
+  applications.*,
+  dup_phone.phone_number AS duplicate_phone
+FROM
+  applications
+INNER JOIN 
+  applicants
+ON
+  applications.applicant_id = applicants.id
+INNER JOIN 
+  (
+    SELECT 
+      phone_number,
+      COUNT(phone_number)
+    FROM 
+      applicants 
+    GROUP BY 
+      phone_number
+    HAVING 
+      COUNT(phone_number) > 1
+  ) dup_phone 
+ON 
+  applicants.phone_number = dup_phone.phone_number
+WHERE 
+  applications.urn IS NOT NULL
+
+UNION
+
+SELECT 
+  applications.*,
+  dup_passport.passport_number AS duplicate_passport
+FROM
+  applications
+INNER JOIN 
+  applicants
+ON
+  applications.applicant_id = applicants.id
+INNER JOIN 
+  (
+    SELECT 
+      passport_number,
+      COUNT(passport_number)
+    FROM 
+      applicants 
+    GROUP BY 
+      passport_number
+    HAVING 
+      COUNT(passport_number) > 1
+  ) dup_passport 
+ON 
+  applicants.passport_number = dup_passport.passport_number
+WHERE 
+  applications.urn IS NOT NULL

--- a/spec/features/admin_console/duplicates_search_spec.rb
+++ b/spec/features/admin_console/duplicates_search_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe "Duplicates Search" do
     then_i_see_matching_duplicates_by_passport_number
   end
 
+  it "the view renders even where there are 'in progress' applications" do
+    given_i_am_signed_as_an_admin
+    when_there_are_in_progress_applications
+    when_i_visit_the_duplicates_page
+    then_i_see_the_in_progress_applications
+  end
+
   def when_i_search_for_a_duplicate_by(type)
     visit duplicates_path
     case type
@@ -40,6 +47,18 @@ RSpec.describe "Duplicates Search" do
     when "passport number"
       all("a", text: "123456").first.click
     end
+  end
+
+  def when_there_are_in_progress_applications
+    create(:application, applicant: nil, urn: nil, application_progress: nil)
+  end
+
+  def when_i_visit_the_duplicates_page
+    visit duplicates_path
+  end
+
+  def then_i_see_the_in_progress_applications
+    expect(page).to have_content("Duplicated Applications")
   end
 
   def then_i_see_matching_duplicates


### PR DESCRIPTION
## Description

There was an error where the applications that are "in progress" or "abandoned", will be included on the
duplicates table, but since the wont have yet all the required data, like an `application_progress` relationship,
it will return errors when trying to display them on the Duplicates view.

This updates the database view query to only include applications that have a URN therefore have already being submitted.
