### PR TITLE
Add `Student Loan` question in personal details step

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -14,6 +14,7 @@
 #  passport_number :text
 #  phone_number    :text
 #  sex             :text
+#  student_loan    :boolean
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  school_id       :bigint

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -27,6 +27,7 @@
 #  sex                           :string
 #  start_date                    :date
 #  state_funded_secondary_school :boolean
+#  student_loan                  :boolean
 #  subject                       :string
 #  visa_type                     :string
 #  created_at                    :datetime         not null

--- a/app/models/form/completeness_check.rb
+++ b/app/models/form/completeness_check.rb
@@ -19,7 +19,7 @@ class Form::CompletenessCheck
   end
 
   def failure_reason
-    return nil if missing_fields.blank?
+    return if missing_fields.blank?
 
     "missing fields: #{missing_fields.join(', ')}"
   end
@@ -37,6 +37,6 @@ private
   end
 
   def missing_fields
-    required_fields.select { form.public_send(_1).blank? }
+    required_fields.select { form.public_send(_1).to_s.blank? }
   end
 end

--- a/app/services/submit_form.rb
+++ b/app/services/submit_form.rb
@@ -66,6 +66,7 @@ private
       sex: form.sex,
       passport_number: form.passport_number,
       nationality: form.nationality,
+      student_loan: form.student_loan,
       address_attributes: {
         address_line_1: form.address_line_1,
         address_line_2: form.address_line_2,

--- a/app/steps/base_step/answer.rb
+++ b/app/steps/base_step/answer.rb
@@ -1,4 +1,6 @@
 class BaseStep::Answer
+  include ActionView::Helpers::TranslationHelper
+
   def initialize(value:, label:, hint: nil, field_name: nil)
     @value = value
     @label = label
@@ -12,6 +14,7 @@ private
 
   def format(value)
     return value.strftime("%d-%m-%Y") if value.is_a?(Date)
+    return t("steps.#{value}") if [TrueClass, FalseClass].include?(value.class)
 
     value
   end

--- a/app/steps/personal_details_step.rb
+++ b/app/steps/personal_details_step.rb
@@ -13,6 +13,7 @@ class PersonalDetailsStep < BaseStep
     sex
     nationality
     passport_number
+    student_loan
   ].freeze
 
   OPTIONAL_FIELDS = %i[
@@ -33,7 +34,13 @@ class PersonalDetailsStep < BaseStep
   def configure_step
     @question = t("steps.personal_details.question")
     @question_type = :multi
+    @student_loan_valid_answers = [
+      Answer.new(value: true, label: t("steps.contract_details.answers.yes.text")),
+      Answer.new(value: false, label: t("steps.contract_details.answers.no.text")),
+    ]
   end
+
+  attr_reader :student_loan_valid_answers
 
   def template
     "step/personal_details"

--- a/app/views/step/personal_details.html.erb
+++ b/app/views/step/personal_details.html.erb
@@ -6,36 +6,43 @@
   <div class="govuk-grid-column-full">
     <%= form_with(url: @step.path, model: @step, method: :patch, local: true) do |f| %>
     <%= f.govuk_error_summary %>
-      <h1 class="govuk-heading-l">
-        <%= @step.question %>
-      </h1>
+    <h1 class="govuk-heading-l">
+      <%= @step.question %>
+    </h1>
 
-      <%= f.govuk_text_field :given_name, label: { text: @step.given_name_label, size: "s" } %>
-      <%= f.govuk_text_field :middle_name, label: { text: @step.middle_name_label, size: "s" } %>
-      <%= f.govuk_text_field :family_name, label: { text: @step.family_name_label, size: "s" } %>
-      <%= f.govuk_text_field :email_address, label: { text: @step.email_address_label, size: "s" }, hint: { text: t("steps.personal_details.email_address.hint") } %>
-      <%= f.govuk_text_field :phone_number,
+    <%= f.govuk_text_field :given_name, label: { text: @step.given_name_label, size: "s" } %>
+    <%= f.govuk_text_field :middle_name, label: { text: @step.middle_name_label, size: "s" } %>
+    <%= f.govuk_text_field :family_name, label: { text: @step.family_name_label, size: "s" } %>
+    <%= f.govuk_text_field :email_address, label: { text: @step.email_address_label, size: "s" }, hint: { text: t("steps.personal_details.email_address.hint") } %>
+    <%= f.govuk_text_field :phone_number,
         label: { text: @step.phone_number_label, size: "s" },
         hint: { text:  t("steps.personal_details.phone_number.hint") }
-      %>
-      <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: @step.date_of_birth_label, size: "s" } %>
+        %>
+    <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: @step.date_of_birth_label, size: "s" } %>
 
-      <%= f.govuk_fieldset legend: { text: t("steps.personal_details.address.text"), size: 's' } do %>
-        <%= f.govuk_text_field :address_line_1, label: { text: @step.address_line_1_label, size: "s" } %>
-        <%= f.govuk_text_field :address_line_2, label: { text: @step.address_line_2_label, size: "s" } %>
-        <%= f.govuk_text_field :city, label: { text: @step.city_label, size: "s" } %>
-        <%= f.govuk_text_field :postcode, label: { text: @step.postcode_label, size: "s" } %>
+    <%= f.govuk_fieldset legend: { text: t("steps.personal_details.address.text"), size: 's' } do %>
+      <%= f.govuk_text_field :address_line_1, label: { text: @step.address_line_1_label, size: "s" } %>
+      <%= f.govuk_text_field :address_line_2, label: { text: @step.address_line_2_label, size: "s" } %>
+      <%= f.govuk_text_field :city, label: { text: @step.city_label, size: "s" } %>
+      <%= f.govuk_text_field :postcode, label: { text: @step.postcode_label, size: "s" } %>
+    <% end %>
+
+    <%= f.govuk_select(:nationality, NATIONALITIES, label: { text: @step.nationality_label, size: "s" }, options: { include_blank: true }) %>
+
+    <%= f.govuk_radio_buttons_fieldset(:sex, legend: { text: @step.sex_label, size: "s" }) do %>
+      <% @step.class::SEX_OPTIONS.each_with_index do |value, i| %>
+        <%= f.govuk_radio_button :sex, value, label: { text: value.humanize }, link_errors: i.zero? %>
       <% end %>
+    <% end %>
 
-      <%= f.govuk_select(:nationality, NATIONALITIES, label: { text: @step.nationality_label, size: "s" }, options: { include_blank: true }) %>
+    <%= f.govuk_text_field :passport_number, label: { text: @step.passport_number_label, size: "s" } %>
 
-      <%= f.govuk_radio_buttons_fieldset(:sex, legend: { text: @step.sex_label, size: "s" }) do %>
-        <% @step.class::SEX_OPTIONS.each_with_index do |value, i| %>
-          <%= f.govuk_radio_button :sex, value, label: { text: value.humanize }, link_errors: i.zero? %>
-        <% end %>
+    <%= f.govuk_radio_buttons_fieldset(:student_loan, legend: { text: @step.student_loan_label, size: "s" }) do %>
+      <div class="govuk-hint" id="personal-details-step-student-loan-hint"><%= t('steps.personal_details.student_loan.hint') %></div>
+      <% @step.student_loan_valid_answers.each_with_index do |answer, i| %>
+        <%= f.govuk_radio_button :student_loan, answer.value, label: { text: answer.label }, link_errors: i.zero? %>
       <% end %>
-
-      <%= f.govuk_text_field :passport_number, label: { text: @step.passport_number_label, size: "s" } %>
+    <% end %>
 
     <%= f.govuk_submit %>
     <% end %>

--- a/app/views/system_admin/applicants/show.html.erb
+++ b/app/views/system_admin/applicants/show.html.erb
@@ -102,6 +102,10 @@ end %>
           row.with_key(text: 'Passport number')
           row.with_value(text: @applicant.passport_number)
         end 
+        summary_list.with_row do |row|
+          row.with_key(text: 'Student Loan')
+          row.with_value(text: @applicant.student_loan ? "Yes" : "No")
+        end
     end %>
     <h4 class="govuk-heading-m">Applicant Address</h4>
     <%= govuk_summary_list(actions: false) do |summary_list|

--- a/db/migrate/20230825102934_add_student_loan_columns.rb
+++ b/db/migrate/20230825102934_add_student_loan_columns.rb
@@ -1,0 +1,8 @@
+# rubocop:disable Rails/ThreeStateBooleanColumn
+class AddStudentLoanColumns < ActiveRecord::Migration[7.0]
+  def change
+    add_column :forms, :student_loan, :boolean
+    add_column :applicants, :student_loan, :boolean
+  end
+end
+# rubocop:enable Rails/ThreeStateBooleanColumn

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,6 +47,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_29_093918) do
     t.datetime "updated_at", null: false
     t.bigint "school_id"
     t.string "middle_name"
+    t.boolean "student_loan"
     t.index ["school_id"], name: "index_applicants_on_school_id"
   end
 
@@ -123,6 +124,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_29_093918) do
     t.string "school_postcode"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "student_loan"
   end
 
   create_table "schools", force: :cascade do |t|

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -12,6 +12,7 @@
 #  passport_number :text
 #  phone_number    :text
 #  sex             :text
+#  student_loan    :boolean
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  school_id       :bigint
@@ -32,6 +33,7 @@ FactoryBot.define do
     nationality { Faker::Nation.nationality }
     passport_number { Faker::Number.number(digits: 9) }
     phone_number { Faker::PhoneNumber.cell_phone_in_e164 }
+    student_loan { [true, false].sample }
     sex { %w[female male].sample }
 
     school factory: %i[school], strategy: :create

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -27,6 +27,7 @@
 #  sex                           :string
 #  start_date                    :date
 #  state_funded_secondary_school :boolean
+#  student_loan                  :boolean
 #  subject                       :string
 #  visa_type                     :string
 #  created_at                    :datetime         not null
@@ -87,6 +88,7 @@ FactoryBot.define do
       postcode { Faker::Address.postcode }
       passport_number { Faker::Alphanumeric.alpha(number: 10) }
       nationality { NATIONALITIES.sample }
+      student_loan { true }
       school_headteacher_name { Faker::Name.name }
       school_name { Faker::Educator.secondary_school }
       school_address_line_1 { Faker::Address.street_address }

--- a/spec/models/form/completeness_check_spec.rb
+++ b/spec/models/form/completeness_check_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Form::CompletenessCheck do
       it { expect(check.failure_reason).to be_nil }
     end
 
+    context "when boolean field hold false value" do
+      let(:form) { build(:form, :complete, student_loan: false) }
+
+      it { expect(check.failure_reason).to be_nil }
+    end
+
     context "when incomplete" do
       context "for teacher" do
         %i[
@@ -31,6 +37,7 @@ RSpec.describe Form::CompletenessCheck do
           postcode
           passport_number
           nationality
+          student_loan
           school_headteacher_name
           school_name
           school_address_line_1
@@ -65,6 +72,7 @@ RSpec.describe Form::CompletenessCheck do
           postcode
           passport_number
           nationality
+          student_loan
           school_headteacher_name
           school_name
           school_address_line_1

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -27,6 +27,7 @@
 #  sex                           :string
 #  start_date                    :date
 #  state_funded_secondary_school :boolean
+#  student_loan                  :boolean
 #  subject                       :string
 #  visa_type                     :string
 #  created_at                    :datetime         not null

--- a/spec/models/summary_spec.rb
+++ b/spec/models/summary_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Summary do
       postcode: "EC1 2AA",
       passport_number: "OE75370015I",
       nationality: NATIONALITIES[31],
+      student_loan: true,
       school_headteacher_name: "Miss A. Morice",
       school_name: "School one",
       school_address_line_1: "line 3",
@@ -96,6 +97,7 @@ RSpec.describe Summary do
         { key: { text: "Select your sex" }, value: { text: "female" } },
         { key: { text: "Select your nationality" }, value: { text: "Bulgarian" } },
         { key: { text: "Enter your passport number, as it appears on your passport" }, value: { text: "OE75370015I" } },
+        { key: { text: "Are you currently repaying a student loan in England?" }, value: { text: "Yes" } },
       ]
     end
 

--- a/spec/steps/personal_details_step_spec.rb
+++ b/spec/steps/personal_details_step_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe PersonalDetailsStep, type: :model do
                      sex
                      nationality
                      passport_number
+                     student_loan
                    ],
                    optional_fields: %i[middle_name address_line_2],
                    question: "Personal information",

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -77,6 +77,7 @@ RSpec.shared_context "with common application form steps" do
     select("Senegalese")
     choose("Male")
     fill_in("personal_details_step[passport_number]", with: "000")
+    choose("No")
 
     click_button("Continue")
   end


### PR DESCRIPTION
-------

## Description

Add student_loan question to personal details page

save value in form and upon submissions adds it to the applicant.student_loan field

## Dependency

- [x]  #209 

## Personal Details page
![image](https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/139925286/fdda466a-759f-4de4-873c-f5afd6076446)


## Summary page
![image](https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/139925286/6045e005-797d-4ab1-b760-eab31dc7419f)


## Trello Card Link
[StudentLoan](https://trello.com/c/Ige3Yr3T/180-sadd-in-question-about-student-loan-to-personal-details-page-as-a-preference-or-on-additional-button-page-if-needed)