### PR TITLE
Remove nationalities

### DIFF
--- a/config/initializers/nationalities.rb
+++ b/config/initializers/nationalities.rb
@@ -73,7 +73,6 @@ NATIONALITIES = [
   "Ecuadorean",
   "Egyptian",
   "Emirati",
-  "English",
   "Equatorial Guinean",
   "Eritrean",
   "Estonian",
@@ -181,7 +180,6 @@ NATIONALITIES = [
   "Samoan",
   "Sao Tomean",
   "Saudi Arabian",
-  "Scottish",
   "Senegalese",
   "Serbian",
   "Sierra Leonean",
@@ -226,7 +224,6 @@ NATIONALITIES = [
   "Wallisian",
   "Vincentian",
   "Yemeni",
-  "Welsh",
   "Zimbabwean",
   "Zambian",
 ].freeze

--- a/spec/support/application_form_steps.rb
+++ b/spec/support/application_form_steps.rb
@@ -74,7 +74,7 @@ RSpec.shared_context "with common application form steps" do
     fill_in("applicants_personal_detail[address_line_2]", with: "Office 20")
     fill_in("applicants_personal_detail[city]", with: "London")
     fill_in("applicants_personal_detail[postcode]", with: "AS1 1AA")
-    select("English")
+    select("Senegalese")
     choose("Male")
     fill_in("applicants_personal_detail[passport_number]", with: "000")
 


### PR DESCRIPTION
-------

## Description
`English`, `Scottish` and `Welsh` are removed from the nationalities list

## Trello Card Link
[Remove Nationalites](https://trello.com/c/KQ2ojIx3/182-sremove-english-welsh-and-scottish-from-nationalities-drop-down)
https://trello.com/c/