### PR TITLE
Fix audit errors

### DIFF
--- a/app/controllers/system_admin/audits_controller.rb
+++ b/app/controllers/system_admin/audits_controller.rb
@@ -2,7 +2,7 @@ module SystemAdmin
   class AuditsController < AdminController
     include Pagy::Backend
     def index
-      @pagy, @audits = pagy(Audited::Audit.all.order(created_at: :desc), items: 10)
+      @pagy, @audits = pagy(Audited::Audit.all.where.not(user_id: nil).order(created_at: :desc), items: 10)
     end
   end
 end

--- a/app/models/application_progress.rb
+++ b/app/models/application_progress.rb
@@ -21,7 +21,7 @@
 #  application_id                    :bigint
 #
 class ApplicationProgress < ApplicationRecord
-  audited
+  audited on: [:update]
   belongs_to :application
 
   validates :rejection_reason, presence: true, if: :rejection_completed_at?


### PR DESCRIPTION
## Description

There was an error when creating audits for the application progress when a new application was created.
This fix limits the auditing to only when the 'application_progress' model is updated.
Also the controller will fetch audits that have a user_id.

## Trello Card Link

https://trello.com/c/LrzvNeQn
