### PR TITLE
Downgrade sidekiq version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :development do
   gem "web-console"
 end
 
-gem "sidekiq", "~> 7.1"
+gem "sidekiq", "~> 6.5"
 
 gem "sidekiq-cron", "~> 1.10"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,8 +314,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    redis-client (0.17.0)
-      connection_pool
+    redis (4.8.1)
     regexp_parser (2.8.1)
     reline (0.3.4)
       io-console (~> 0.5)
@@ -391,11 +390,10 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.1.4)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
+    sidekiq (6.5.9)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     sidekiq-cron (1.10.1)
       fugit (~> 1.8)
       globalid (>= 1.0.1)
@@ -488,7 +486,7 @@ DEPENDENCIES
   scenic
   sentry-rails (~> 5.11)
   shoulda-matchers (~> 5.0)
-  sidekiq (~> 7.1)
+  sidekiq (~> 6.5)
   sidekiq-cron (~> 1.10)
   simplecov
   sprockets-rails

--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -7,7 +7,7 @@
     "key_vault_app_secret_name": "TRP-APP-SECRETS-PRODUCTION",
     "key_vault_infra_secret_name": "TRP-INFRA-SECRETS-PRODUCTION",
     "enable_monitoring": true,
-    "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+    "startup_command": ["/bin/sh", "-c", "./bin/app-startup.sh"],
     "replicas": 2,
     "memory_max": "1Gi",
     "gov_uk_host_names": [

--- a/terraform/aks/config/qa.tfvars.json
+++ b/terraform/aks/config/qa.tfvars.json
@@ -7,7 +7,7 @@
     "key_vault_app_secret_name": "TRP-APP-SECRETS-QA",
     "key_vault_infra_secret_name": "TRP-INFRA-SECRETS-QA",
     "enable_monitoring": false,
-    "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+    "startup_command": ["/bin/sh", "-c", "./bin/app-startup.sh"],
     "replicas": 1,
     "memory_max": "1Gi",
     "gov_uk_host_names": [

--- a/terraform/aks/config/review.tfvars.json
+++ b/terraform/aks/config/review.tfvars.json
@@ -8,7 +8,7 @@
     "key_vault_app_secret_name": "TRP-APP-SECRETS-REVIEW",
     "key_vault_infra_secret_name": "TRP-INFRA-SECRETS-REVIEW",
     "enable_monitoring": false,
-    "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+    "startup_command": ["/bin/sh", "-c", "./bin/app-startup.sh"],
     "replicas": 1,
     "memory_max": "1Gi"
 }

--- a/terraform/aks/config/staging.tfvars.json
+++ b/terraform/aks/config/staging.tfvars.json
@@ -7,7 +7,7 @@
     "key_vault_app_secret_name": "TRP-APP-SECRETS-STAGING",
     "key_vault_infra_secret_name": "TRP-INFRA-SECRETS-STAGING",
     "enable_monitoring": false,
-    "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+    "startup_command": ["/bin/sh", "-c", "./bin/app-startup.sh"],
     "replicas": 1,
     "memory_max": "1Gi",
     "gov_uk_host_names": [


### PR DESCRIPTION
## Description
* Prod and Staging redis version is not supported by the latest version of sidekiq. Review environment uses docker for redis which picks up the latest version and allowed sidekiq version 7

* udpate startup_command to match Dockerfile