### PR TITLE
Add Kpi status breakdown

### DIFF
--- a/app/models/kpis.rb
+++ b/app/models/kpis.rb
@@ -62,4 +62,8 @@ class Kpis
   def time_to_payment_confirmation
     TimeToPaymentConfirmationQuery.new.call
   end
+
+  def status_breakdown
+    StatusBreakdownQuery.call
+  end
 end

--- a/app/queries/status_breakdown_query.rb
+++ b/app/queries/status_breakdown_query.rb
@@ -1,0 +1,22 @@
+class StatusBreakdownQuery
+  def self.call
+    new.execute
+  end
+
+  def execute
+    ordered_with_defaults(status_breakdown)
+  end
+
+private
+
+  def status_breakdown
+    ApplicationProgress.group(:status).count
+  end
+
+  def ordered_with_defaults(breakdown)
+    ApplicationProgress.statuses.each_with_object({}) do |(key, _), hsh|
+      hsh[key] = breakdown.fetch(key, 0)
+      hsh
+    end
+  end
+end

--- a/app/views/system_admin/dashboard/show.html.erb
+++ b/app/views/system_admin/dashboard/show.html.erb
@@ -141,4 +141,17 @@
     </table>
   </div>
 
+  <div class="kpi-widget status-breakdown">
+    <h3 class="title">Statuses</h3>
+    <table class="kpi-table">
+      <% @kpis.status_breakdown.each do |k,v|%>
+        <tr>
+          <td><%= link_to(k.titleize, applicants_path(search: nil, status: k)) %></td>
+          <td><%= v %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+
+
 </div>

--- a/spec/queries/status_breakdown_query_spec.rb
+++ b/spec/queries/status_breakdown_query_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe StatusBreakdownQuery, type: :service do
+  subject(:breakdown) { described_class.call }
+
+  describe ".call" do
+    let(:expected_breakdown) do
+      {
+        "initial_checks" => 0,
+        "home_office_checks" => 0,
+        "school_checks" => 0,
+        "bank_approval" => 0,
+        "payment_confirmation" => 0,
+        "paid" => 0,
+        "rejected" => 0,
+      }
+    end
+
+    it "returns the ordered application status breakdown" do
+      expect(breakdown).to include(expected_breakdown)
+    end
+
+    context "with data" do
+      before do
+        create(:application, :with_initial_checks_completed)
+      end
+
+      let(:expected_breakdown) do
+        {
+          "initial_checks" => 0,
+          "home_office_checks" => 1,
+          "school_checks" => 0,
+          "bank_approval" => 0,
+          "payment_confirmation" => 0,
+          "paid" => 0,
+          "rejected" => 0,
+        }
+      end
+
+      it "returns the ordered application status breakdown" do
+        expect(breakdown).to include(expected_breakdown)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
Add Kpi status breakdown


## Trello Card Link

https://trello.com/c/hPT1pL2Y/209-add-new-kpi-widget-with-a-breakdown-of-the-each-status