### PR TITLE
Change applicant minimum age from 22 to 21

### DIFF
--- a/app/steps/personal_details_step.rb
+++ b/app/steps/personal_details_step.rb
@@ -80,10 +80,10 @@ private
     return unless date_of_birth.present?
     # rubocop:enable Rails/Blank
 
-    errors.add(:date_of_birth, :below_min_age) if date_of_birth > MIN_AGE.years.ago.to_date
+    errors.add(:date_of_birth, :below_min_age) unless date_of_birth <= MIN_AGE.years.ago.to_date
   end
 
   MAX_AGE = 80
-  MIN_AGE = 22
+  MIN_AGE = 21
   private_constant :MAX_AGE, :MIN_AGE
 end

--- a/config/locales/steps.en.yml
+++ b/config/locales/steps.en.yml
@@ -195,7 +195,7 @@ en:
               blank: Enter your date of birth
               not_in_future: Date of birth cannot be in the future
               over_max_age: Age must be below 80
-              below_min_age: Age must be above 22
+              below_min_age: Age must be above 21
             sex:
               blank: Enter your sex
               inclusion: Enter your sex 

--- a/spec/steps/personal_details_step_spec.rb
+++ b/spec/steps/personal_details_step_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe PersonalDetailsStep, type: :model do
     describe "date_of_birth minimum age" do
       let(:form) { build(:form, date_of_birth: age) }
       let(:error) { step.errors.messages_for(:date_of_birth) }
-      let(:minimum_age) { 22 }
+      let(:minimum_age) { 21 }
 
       before { step.valid? }
 
@@ -189,7 +189,7 @@ RSpec.describe PersonalDetailsStep, type: :model do
 
       it "has MIN_AGE set to 22" do
         min_age = described_class.send(:const_get, :MIN_AGE)
-        expect(min_age).to eq(22)
+        expect(min_age).to eq(21)
       end
     end
 


### PR DESCRIPTION
## Description
Change applicant minimum age from 22 to 21

## Trello Card Link

https://trello.com/c/hx7IeaJA/210-update-applicant-minimum-age-to-21