### PR TITLE
Copy changes for salaried_trainee subject step

### DIFF
--- a/config/locales/steps.en.yml
+++ b/config/locales/steps.en.yml
@@ -84,7 +84,7 @@ en:
         teacher:
           Physics, general or combined science including physics, and languages can be combined with other subjects but must make up at least 50% of your time in the classroom. 
         salaried_trainee:
-          Physics or languages can be combined with other subjects but must make up at least 50% of your course content. This will be validated by Department for Education with the school where you are training.
+          Physics or languages can be combined with other subjects but must make up at least 50% of your course content.
       answers:
         physics:
           text: Physics

--- a/spec/steps/subject_step_spec.rb
+++ b/spec/steps/subject_step_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SubjectStep, type: :model do
   context "salaried_trainee" do
     let(:form) { build(:trainee_form) }
 
-    question_hint = "Physics or languages can be combined with other subjects but must make up at least 50% of your course content. This will be validated by Department for Education with the school where you are training."
+    question_hint = "Physics or languages can be combined with other subjects but must make up at least 50% of your course content."
 
     include_examples "behaves like a step",
                      described_class,


### PR DESCRIPTION
## Description

Please can you remove: This will be validated by Department for Education with the school where you are training.

This is so that it matches the teacher route.

![image](https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/139925286/32e5a4bf-d142-472b-9642-c41df77f661b)


## Trello Card Link
https://trello.com/c/5gpDi3ow/226-please-edit-subject-question-in-salaried-trainee-route