### PR TITLE
When applicant do not follow the form natural step order

### DIFF
--- a/app/models/form/eligibility_check.rb
+++ b/app/models/form/eligibility_check.rb
@@ -40,6 +40,8 @@ class Form::EligibilityCheck
   end
 
   def date_of_entry_eligible?(date_of_entry, start_date)
+    return false unless date_of_entry && start_date
+
     date_of_entry >= start_date - 3.months
   end
 

--- a/app/queries/forms_funnel_query.rb
+++ b/app/queries/forms_funnel_query.rb
@@ -63,7 +63,7 @@ class FormsFunnelQuery
 
     form_dates = date_of_entries.each_with_object([]) do |(id, date_of_entry), list|
       entry = start_dates.detect { |(sid, _)| sid == id }
-      list << [date_of_entry.to_date, entry.last.to_date]
+      list << [date_of_entry.to_date, entry&.last&.to_date]
       list
     end
 


### PR DESCRIPTION
-------

## Description

some user fill in the date-of-entry step before the start-date
and this caused a bug in the form analytic widget which assumed that
the form was filled in the order expected.

TODO: This type of behaviour could be used as a way to flag potential
fraudulent applications.