### PR TITLE
Add report reset button

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,3 +110,4 @@ RSpec/AnyInstance:
 RSpec/MultipleMemoizedHelpers:
   Exclude:
     - 'spec/models/event_spec.rb'
+    - 'spec/helpers/audit_message_helper_spec.rb'

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -136,3 +136,7 @@
     width: 100%;
   }
 }
+
+.audit-key {
+    width: 17em !important;
+}

--- a/app/controllers/system_admin/reports_controller.rb
+++ b/app/controllers/system_admin/reports_controller.rb
@@ -6,15 +6,22 @@ module SystemAdmin
 
     def show
       report = Report.call(params[:id], **report_params)
-      create_audit(action: "Downloaded #{report.name} report")
-
       send_data(report.data, filename: report.filename)
+    end
+
+    def reset
+      Report.reset(params[:id], **reset_report_params)
+      redirect_to(audits_path)
     end
 
   private
 
     def report_params
-      params.permit(:id, :status)
+      params.permit(:id, :status).merge(user: current_user)
+    end
+
+    def reset_report_params
+      params.permit(:id, :status, :timestamp, :arid).merge(user: current_user)
     end
 
     def check_user_roles

--- a/app/models/reports/base.rb
+++ b/app/models/reports/base.rb
@@ -26,5 +26,20 @@ module Reports
     def generate; end
 
     def post_generation_hook; end
+
+    def reset; end
+
+    def timestamp
+      kwargs&.fetch(:timestamp, nil)
+    end
+
+  private
+
+    def timestamp_range
+      return unless timestamp
+
+      t = Time.zone.parse(timestamp)
+      Range.new(t - 1.second, t + 1.second)
+    end
   end
 end

--- a/app/models/reports/home_office_csv.rb
+++ b/app/models/reports/home_office_csv.rb
@@ -13,6 +13,12 @@ module Reports
       applications.update_all(home_office_csv_downloaded_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
     end
 
+    def reset
+      Application
+        .where(home_office_csv_downloaded_at: timestamp_range)
+        .update_all(home_office_csv_downloaded_at: nil) # rubocop:disable Rails/SkipsModelValidations
+    end
+
   private
 
     def rows

--- a/app/models/reports/home_office_excel.rb
+++ b/app/models/reports/home_office_excel.rb
@@ -16,6 +16,12 @@ module Reports
       base_query.update_all(home_office_csv_downloaded_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
     end
 
+    def reset
+      Application
+        .where(home_office_csv_downloaded_at: timestamp_range)
+        .update_all(home_office_csv_downloaded_at: nil) # rubocop:disable Rails/SkipsModelValidations
+    end
+
   private
 
     def workbook

--- a/app/models/reports/payroll.rb
+++ b/app/models/reports/payroll.rb
@@ -13,6 +13,12 @@ module Reports
       applications.update_all(payroll_csv_downloaded_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
     end
 
+    def reset
+      Application
+        .where(payroll_csv_downloaded_at: timestamp_range)
+        .update_all(payroll_csv_downloaded_at: nil) # rubocop:disable Rails/SkipsModelValidations
+    end
+
   private
 
     def rows

--- a/app/models/reports/qa_report.rb
+++ b/app/models/reports/qa_report.rb
@@ -20,6 +20,10 @@ module Reports
       kwargs.fetch(:status)
     end
 
+    def reset
+      QaStatus.where(status: status, date: timestamp_range).delete_all
+    end
+
   private
 
     def applications

--- a/app/models/reports/standing_data.rb
+++ b/app/models/reports/standing_data.rb
@@ -13,6 +13,12 @@ module Reports
       applications.update_all(standing_data_csv_downloaded_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
     end
 
+    def reset
+      Application
+        .where(standing_data_csv_downloaded_at: timestamp_range)
+        .update_all(standing_data_csv_downloaded_at: nil) # rubocop:disable Rails/SkipsModelValidations
+    end
+
   private
 
     def rows

--- a/app/services/report.rb
+++ b/app/services/report.rb
@@ -12,6 +12,14 @@ class Report
     report = new(...)
     report.data
     report.post_generation_hook
+    report.create_audit
+    report
+  end
+
+  def self.reset(...)
+    report = new(...)
+    report.reset
+    report.create_audit
     report
   end
 
@@ -28,16 +36,47 @@ class Report
   delegate :name, to: :report
   delegate :filename, to: :report
   delegate :post_generation_hook, to: :report
+  delegate :reset, to: :report
 
   def data
     @data ||= report.generate
+  end
+
+  def create_audit
+    return reset_audit_trail if report.timestamp
+
+    Audited::Audit.create(
+      action: "Downloaded #{name} report",
+      user: user,
+      comment: {
+        resettable: true,
+        id: @kwargs.fetch(:id),
+        status: @kwargs.fetch(:status, nil),
+      }.to_json,
+    )
   end
 
 private
 
   attr_reader :report_class, :kwargs
 
+  def reset_audit_trail
+    audit = Audited::Audit.find_by(id: audit_id)
+    comment = JSON.parse(audit.comment)
+    comment["resettable"] = false
+    audit.update(comment: comment.to_json)
+    Audited::Audit.create(action: "Reset #{name} report", user: user)
+  end
+
   def report
     @report ||= report_class.new(**kwargs)
+  end
+
+  def audit_id
+    @kwargs.fetch(:arid)
+  end
+
+  def user
+    @kwargs.fetch(:user)
   end
 end

--- a/app/services/report.rb
+++ b/app/services/report.rb
@@ -46,6 +46,7 @@ class Report
     return reset_audit_trail if report.timestamp
 
     Audited::Audit.create(
+      auditable_type: "Report",
       action: "Downloaded #{name} report",
       user: user,
       comment: {

--- a/app/views/system_admin/audits/_app_settings.html.erb
+++ b/app/views/system_admin/audits/_app_settings.html.erb
@@ -1,0 +1,3 @@
+application settings
+
+<%= render("changed_summary", audit: audit) %>

--- a/app/views/system_admin/audits/_application_progress.html.erb
+++ b/app/views/system_admin/audits/_application_progress.html.erb
@@ -1,0 +1,6 @@
+application progress
+<%= govuk_tag(
+text: govuk_link_to(audit.auditable&.application&.urn, applicant_path(audit.auditable&.application&.applicant)),
+colour: "orange") %>.
+
+<%= render("changed_summary", audit: audit) %>

--- a/app/views/system_admin/audits/_changed_summary.html.erb
+++ b/app/views/system_admin/audits/_changed_summary.html.erb
@@ -1,0 +1,16 @@
+<div>
+Changed fields:
+
+  <dl class="govuk-summary-list govuk-!-margin-left-7">
+    <% audit.audited_changes.except("status").each do |key, (from, to)| %>
+    <% next if changed_value(from) == changed_value(to) %>
+    <div class="audit">
+      <dt class="govuk-summary-list__key audit-key"><%= key %> </dt>
+      <dd class="govuk-summary-list__value">
+        from: <span class="govuk-tag--pink govuk-!-padding-left-1"> <%= changed_value(from) %> </span>,
+        to: <span class="govuk-tag--green govuk-!-padding-right-1 govuk-!-padding-left-1"> <%= changed_value(to) %> </span>
+      </dd>
+    </div>
+    <% end %>
+  </dl>
+</div>

--- a/app/views/system_admin/audits/_report.html.erb
+++ b/app/views/system_admin/audits/_report.html.erb
@@ -1,0 +1,10 @@
+<% if display_reset_button?(audit) %>
+<% name, qa_status = report_name_args(audit) %>
+
+<%= form_tag(reset_report_path(id: name), method: :post) do  %>
+  <%= hidden_field_tag(:arid, audit.id) %>
+  <%= hidden_field_tag(:timestamp, audit.created_at) %>
+  <%= (qa_status ? hidden_field_tag(:status, qa_status) : nil) %>
+  <%= button_tag("Reset report", class: govuk_button_classes) %>
+<% end %>
+<% end %>

--- a/app/views/system_admin/audits/_user.html.erb
+++ b/app/views/system_admin/audits/_user.html.erb
@@ -1,0 +1,14 @@
+<% if audit.action == "create" %>
+a new user entity
+<%= govuk_tag(text: audit.audited_changes['email'], colour: 'yellow') %>
+<% end %>
+
+<% if audit.action == "update" %>
+user entity
+<%= render("changed_summary", audit: audit) %>
+<% end %>
+
+<% if audit.action == "destroy" %>
+user entity
+<%= govuk_tag(text: audit.audited_changes['email'], colour: 'yellow') %>
+<% end %>

--- a/app/views/system_admin/audits/index.html.erb
+++ b/app/views/system_admin/audits/index.html.erb
@@ -1,12 +1,19 @@
-<%= govuk_table(classes: "audits-table") do |table|
-      table.with_caption(size: 'l', text: 'Audits')
-      table.with_body do |body|
-        @audits.each do |audit|
-          body.with_row do |row|
-            row.with_cell(text: audit_message(audit), colspan: 6)
-          end
-        end 
-      end
- end %>
+<ul class="govuk-list govuk-list--bullet">
+  <% @audits.each do |audit| %>
+  <li>
+    <div class="govuk-body govuk-!-margin-top-4">
+      <%= govuk_tag(text: audit.user&.email || "unknown", colour: "grey") %>
+      <%= govuk_tag(text: past_tense_action(audit.action), colour: action_colour(audit.action)) %>
+
+      <%= render(audit_template(audit), audit: audit) %>
+      <div>
+        <%= govuk_tag(text: audit.created_at.strftime("%d/%m/%Y %H:%M:%S"), colour: "grey") %>
+        (<%= time_ago_in_words(audit.created_at) %> ago)
+      </div>
+    </div>
+  </li>
+  <%= govuk_section_break(visible: true) %>
+  <% end %>
+</ul>
 
 <%= govuk_pagination(pagy: @pagy) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,11 @@ Rails.application.routes.draw do
     resources :users, except: %i[show]
     resource :settings, only: %i[edit update]
     get "/dashboard", to: "dashboard#show"
-    resources "reports", only: %i[show index]
+    resources "reports", only: %i[show index] do
+      member do
+        post "reset"
+      end
+    end
     get "/duplicates", to: "applicants#duplicates"
     get "/audits", to: "audits#index"
 

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -12,5 +12,17 @@
 FactoryBot.define do
   factory :role do
     name { "Admin" }
+
+    factory :admin_role do
+      name { "admin" }
+    end
+
+    factory :super_admin_role do
+      name { "super_admin" }
+    end
+
+    factory :manager_role do
+      name { "manager" }
+    end
   end
 end

--- a/spec/helpers/audit_message_helper_spec.rb
+++ b/spec/helpers/audit_message_helper_spec.rb
@@ -1,168 +1,176 @@
 require "rails_helper"
 
 RSpec.describe AuditMessageHelper do
-  include ActiveSupport::Testing::TimeHelpers
+  let(:audit) do
+    json_comment = nil
+    json_comment = comment.to_json if comment
+    build(
+      :audit,
+      action: action,
+      user: user,
+      auditable_type: auditable_type,
+      comment: json_comment,
+    )
+  end
+  let(:action) { "Something happened" }
+  let(:user) { build(:user, email: "user@example.com") }
+  let(:auditable_type) { "ApplicationProgress" }
+  let(:comment) { nil }
 
-  describe "#audit_message" do
-    let(:user) { build(:user, email: "user@example.com") }
-    let(:timestamp) { "10/09/2023 12:00:00" }
+  describe "audit_template" do
+    subject(:audit_template) { helper.audit_template(audit) }
 
-    context "a generic audit" do
-      let(:audit) { build(:audit, action: "generic audit message", user: user, created_at: Time.zone.parse(timestamp)) }
+    context "for application progress" do
+      let(:auditable_type) { "ApplicationProgress" }
 
-      it "includes the auditee email" do
-        expect(helper.audit_message(audit)).to include("user@example.com")
-      end
-
-      it "includes the action text" do
-        expect(helper.audit_message(audit)).to include("generic audit message")
-      end
-
-      it "includes the timestamp" do
-        expect(helper.audit_message(audit)).to include(timestamp)
-      end
+      it { is_expected.to eq("application_progress") }
     end
 
-    context "an audit for a user action" do
-      let(:audit) { build(:audit, action: action, user: user, auditable: user, audited_changes: { "email" => ["otheruser@example.com", "other-user@example.com"] }, created_at: Time.zone.parse(timestamp)) }
+    context "for user" do
+      let(:auditable_type) { "User" }
 
-      describe "create" do
-        let(:action) { "create" }
-
-        it "includes the auditee email" do
-          expect(helper.audit_message(audit)).to include("user@example.com")
-        end
-
-        it "includes the action text" do
-          expect(helper.audit_message(audit)).to include("created")
-        end
-
-        it "includes the entity name" do
-          expect(helper.audit_message(audit)).to include("User entity")
-        end
-
-        it "includes the user email" do
-          expect(helper.audit_message(audit)).to include("otheruser@example.com")
-        end
-
-        it "includes the timestamp" do
-          expect(helper.audit_message(audit)).to include(timestamp)
-        end
-      end
-
-      describe "update" do
-        let(:action) { "update" }
-
-        it "includes the auditee email" do
-          expect(helper.audit_message(audit)).to include("user@example.com")
-        end
-
-        it "includes the action text" do
-          expect(helper.audit_message(audit)).to include("updated")
-        end
-
-        it "includes the entity name" do
-          expect(helper.audit_message(audit)).to include("User entity")
-        end
-
-        it "includes the user email changes" do
-          expect(helper.audit_message(audit)).to include("otheruser@example.com")
-          expect(helper.audit_message(audit)).to include("other-user@example.com")
-        end
-
-        it "includes the timestamp" do
-          expect(helper.audit_message(audit)).to include(timestamp)
-        end
-      end
-
-      describe "destroy" do
-        let(:action) { "destroy" }
-
-        it "includes the auditee email" do
-          expect(helper.audit_message(audit)).to include("user@example.com")
-        end
-
-        it "includes the action text" do
-          expect(helper.audit_message(audit)).to include("destroyed")
-        end
-
-        it "includes the entity name" do
-          expect(helper.audit_message(audit)).to include("User entity")
-        end
-
-        it "includes the user email" do
-          expect(helper.audit_message(audit)).to include("otheruser@example.com")
-        end
-
-        it "includes the timestamp" do
-          expect(helper.audit_message(audit)).to include(timestamp)
-        end
-      end
+      it { is_expected.to eq("user") }
     end
 
-    context "an audit for an application action" do
-      let(:application) { create(:application) }
-      let(:progress) { build(:application_progress, application:) }
-      let(:audit) { build(:audit, action: "update", user: user, auditable: progress, audited_changes: { "school_checks_completed_at" => ["", "2023-08-25"], "banking_approval_completed_at" => %w[2023-08-25 2023-09-10] }, created_at: Time.zone.parse(timestamp)) }
+    context "for appsettings" do
+      let(:auditable_type) { "AppSettings" }
 
-      it "includes the auditee email" do
-        expect(helper.audit_message(audit)).to include("user@example.com")
-      end
-
-      it "includes the action text" do
-        expect(helper.audit_message(audit)).to include("updated")
-      end
-
-      it "includes the entity name" do
-        expect(helper.audit_message(audit)).to include("application progress")
-      end
-
-      it "includes the entity id link" do
-        expect(helper.audit_message(audit)).to include("/applicants/#{application.applicant_id}")
-      end
-
-      context "includes the changes" do
-        it "from empty field" do
-          expect(helper.audit_message(audit)).to include("school_checks_completed_at")
-          expect(helper.audit_message(audit)).to include("&lt;empty&gt;")
-        end
-
-        it "from non-empty field" do
-          expect(helper.audit_message(audit)).to include("banking_approval_completed_at")
-          expect(helper.audit_message(audit)).to include("2023-08-25")
-          expect(helper.audit_message(audit)).to include("2023-09-10")
-        end
-      end
-
-      it "includes the timestamp" do
-        expect(helper.audit_message(audit)).to include(timestamp)
-      end
+      it { is_expected.to eq("app_settings") }
     end
 
-    context "an audit for an app settings action" do
-      let(:audit) { build(:audit, action: "update", user: user, auditable_type: "AppSettings", audited_changes: { "service_start_date" => %w[2022-09-01 2023-08-25] }, created_at: Time.zone.parse(timestamp)) }
+    context "for report" do
+      let(:auditable_type) { "Report" }
 
-      it "includes the auditee email" do
-        expect(helper.audit_message(audit)).to include("user@example.com")
-      end
-
-      it "includes the action text" do
-        expect(helper.audit_message(audit)).to include("updated")
-      end
-
-      it "includes the entity name" do
-        expect(helper.audit_message(audit)).to include("application settings")
-      end
-
-      it "includes the changes" do
-        expect(helper.audit_message(audit)).to include("2022-09-01")
-        expect(helper.audit_message(audit)).to include("2023-08-25")
-        expect(helper.audit_message(audit)).to include("service_start_date")
-      end
-
-      it "includes the timestamp" do
-        expect(helper.audit_message(audit)).to include(timestamp)
-      end
+      it { is_expected.to eq("report") }
     end
+
+    context "for any other entity" do
+      let(:auditable_type) { "foo" }
+
+      it { is_expected.to eq("generic") }
+    end
+  end
+
+  describe "past_tense_action" do
+    subject(:past_tense_action) { helper.past_tense_action(action) }
+
+    context "when action is create" do
+      let(:action) { "create" }
+
+      it { is_expected.to eq("created") }
+    end
+
+    context "when action is update" do
+      let(:action) { "update" }
+
+      it { is_expected.to eq("updated") }
+    end
+
+    context "when action is destroy" do
+      let(:action) { "destroy" }
+
+      it { is_expected.to eq("destroyed") }
+    end
+
+    context "when action is anything else" do
+      let(:action) { "something happen" }
+
+      it { is_expected.to eq("something happen") }
+    end
+  end
+
+  describe "action_colour" do
+    subject(:action_colour) { helper.action_colour(action) }
+
+    context "when action is create" do
+      let(:action) { "create" }
+
+      it { is_expected.to eq("green") }
+    end
+
+    context "when action is update" do
+      let(:action) { "update" }
+
+      it { is_expected.to eq("blue") }
+    end
+
+    context "when action is destroy" do
+      let(:action) { "destroy" }
+
+      it { is_expected.to eq("red") }
+    end
+
+    context "when action is anything else" do
+      let(:action) { "something happen" }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "changed_value" do
+    subject(:changed_value) { helper.changed_value(value) }
+
+    context "when value in not blank" do
+      let(:value) { "foo" }
+
+      it { is_expected.to eq(value) }
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to eq("empty") }
+    end
+
+    context "when value is ''" do
+      let(:value) { "" }
+
+      it { is_expected.to eq("empty") }
+    end
+  end
+
+  describe "display_reset_button?" do
+    subject(:display_reset_button) { helper.display_reset_button?(audit) }
+
+    let(:auditable_type) { "Report" }
+    let(:user) { build(:user, email: "user@example.com", roles: [role]) }
+    let(:comment) { { resettable: true } }
+    let(:role) { build(:admin_role) }
+
+    before { allow(helper).to receive(:current_user).and_return(user) }
+
+    context "return true when feature enabled and user has role admin and report has not been reset yet" do
+      before { Flipper.enable(:reset_reports) }
+      after { Flipper.disable(:reset_reports) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "return false when feature disabled" do
+      before { Flipper.disable(:reset_reports) }
+      after { Flipper.disable(:reset_reports) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "return false when user not role admin" do
+      let(:role) { build(:manager_role) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "return false when report already resetted" do
+      let(:comment) { { resettable: false } }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "report_name_args" do
+    subject(:report_name_args) { helper.report_name_args(audit) }
+
+    let(:comment) { { id: 1, status: nil } }
+
+    it { is_expected.to contain_exactly(1, nil) }
   end
 end

--- a/spec/models/reports/home_office_excel_spec.rb
+++ b/spec/models/reports/home_office_excel_spec.rb
@@ -104,5 +104,25 @@ module Reports
         end
       end
     end
+
+    describe "reset" do
+      let(:app) { create(:application, application_progress: build(:application_progress, :home_office_pending)) }
+
+      before { app }
+
+      it "allows previously downloaded applications in a report to be downloaded again" do
+        travel_to(Time.zone.local(2023, 7, 17, 12, 30, 45)) do
+          first_dataset = report.send(:dataset)
+          expect(first_dataset.first).to include(app.urn)
+
+          report.post_generation_hook
+
+          described_class.new(timestamp: Time.zone.now.to_s).reset
+
+          second_dataset = report.send(:dataset)
+          expect(second_dataset.first).to include(app.urn)
+        end
+      end
+    end
   end
 end

--- a/spec/models/reports/qa_report_spec.rb
+++ b/spec/models/reports/qa_report_spec.rb
@@ -88,6 +88,24 @@ module Reports
         expect(report.generate).to include(expected_header.join(","))
       end
     end
+
+    describe "reset" do
+      let(:app) { create(:application) }
+
+      before { app }
+
+      it "allows previously downloaded applications in a report to be downloaded again" do
+        travel_to(Time.zone.local(2023, 7, 17, 12, 30, 45)) do
+          expect(report.generate).to include(app.urn)
+
+          report.post_generation_hook
+
+          described_class.new(status: status, timestamp: Time.zone.now.to_s).reset
+
+          expect(report.generate).to include(app.urn)
+        end
+      end
+    end
   end
 end
 # rubocop:enable Metrics/ExampleLength

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,8 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join("/spec/fixtures")
+  config.fixture_paths = []
+  config.fixture_paths << Rails.root.join("/spec/fixtures")
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/services/report_spec.rb
+++ b/spec/services/report_spec.rb
@@ -26,10 +26,12 @@ RSpec.describe Report do
   end
 
   describe ".call" do
-    subject(:service) { described_class.new(report_id, status:) }
+    subject(:service) { described_class.new(report_id, status:, user:, id:) }
 
     let(:report_id) { "qa" }
     let(:status) { "initial_checks" }
+    let(:user) { build(:user) }
+    let(:id) { report_id }
 
     context "report_name" do
       it { expect(service.name).to eq("reports-qa-report-initial_checks") }
@@ -47,6 +49,69 @@ RSpec.describe Report do
       end
     end
 
+    context "auditing report download" do
+      before do
+        allow(Audited::Audit).to receive(:new).and_return(spy(Audited::Audit)) # rubocop:disable RSpec/VerifiedDoubles
+
+        service.create_audit
+      end
+
+      let(:expected_params) do
+        {
+          action: "Downloaded #{service.name} report",
+          user: user,
+          comment: {
+            resettable: true,
+            id: report_id,
+            status: status,
+          }.to_json,
+        }
+      end
+
+      it { expect(Audited::Audit).to have_received(:new).with(expected_params) }
+    end
+
+    context "auditing report reset" do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:audit) do
+        create(
+          :audit,
+          action: "Downloaded #{service.name} report",
+          user: user,
+          comment: download_audit_comment_param.to_json,
+        )
+      end
+      let(:expected_params) do
+        {
+          action: "Reset #{service.name} report",
+          user: user,
+        }
+      end
+      let(:download_audit_comment_param) do
+        {
+          resettable: true,
+          id: report_id,
+          status: status,
+        }
+      end
+
+      before do
+        audit
+        s = described_class.new(
+          report_id,
+          status: status,
+          user: user,
+          id: id,
+          arid: audit.id,
+          timestamp: audit.created_at,
+        )
+
+        allow(Audited::Audit).to receive(:new).and_return(spy(Audited::Audit)) # rubocop:disable RSpec/VerifiedDoubles
+        s.create_audit
+      end
+
+      it { expect(Audited::Audit).to have_received(:new).with(expected_params) }
+    end
+
     # rubocop:disable RSpec/VerifiedDoubles
     context "qa report data" do
       let(:report) { spy(Reports::QaReport) }
@@ -56,7 +121,7 @@ RSpec.describe Report do
         service.data
       end
 
-      it { expect(Reports::QaReport).to have_received(:new).with(status:) }
+      it { expect(Reports::QaReport).to have_received(:new).with(id:, status:, user:) }
       it { expect(report).to have_received(:generate) }
     end
 

--- a/spec/services/report_spec.rb
+++ b/spec/services/report_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Report do
       let(:expected_params) do
         {
           action: "Downloaded #{service.name} report",
+          auditable_type: "Report",
           user: user,
           comment: {
             resettable: true,


### PR DESCRIPTION
## Description
In order to render the ops teams self sufficient add the ability to reset a specific report when a error has occured. (ie file lost) 

Condition:
When feature `Flipper.enabled?(:reset_reports)` 
and the current user has the role admin 
and the report has not been already resetted
Then display a reset report button

Screenshots
Before:
![image](https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/139925286/de5652e0-8f24-4ad6-93aa-b14fa977588c)


After:
![image](https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/139925286/b7240e84-63b8-44e5-b0fc-8348252b2c8e)

After reset report:
![image](https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/139925286/08de2edc-3a8f-47d6-8800-218500952c45)
