### PR TITLE
Add warning on sidekiq gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,9 @@ group :development do
   gem "web-console"
 end
 
-gem "sidekiq", "~> 6.5"
+# WARNING
+# only update the sidekiq gem when the available azure redis version is 7.x or above
+gem "sidekiq", "~> 6.5" # /!\ sidekiq version 7 has dropped support for redis version 6 which is the latest redis version on azure.
 
 gem "sidekiq-cron", "~> 1.11"
 


### PR DESCRIPTION
Currently the Azure only offer redis version 6.x
However from sidekiq version 7.x, support for redis 6.x has been
dropped.

This issue affected the Azure platform and not the Review environment
which uses docker, which provides the latest version of redis.