### PR TITLE
Update contract start date rules (#265)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ When adding / removing or editing along side the code changes you will need to u
 available environments.
 Run the following command `make <environment> edit-app-secrets`
 
+#### Contract Start Date
+The environment variable `CONTRACT_START_MONTHS_LIMIT` can be set to `5` to override 
+the default of six months prior to the current service start date.
+`AppSettings.current.service_start_date`.
+This can be set to either `5` or `6` anything else will default to `6`.
+
 ### SSH access
 
 Access a deploy with the command `make <environment> ssh`.

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ available environments.
 Run the following command `make <environment> edit-app-secrets`
 
 #### Contract Start Date
-The environment variable `CONTRACT_START_MONTHS_LIMIT` can be set to `5` to override 
+The custom configuration entry `config.x.form_eligibility.contract_start_months_limit` can be set to `5` to override 
 the default of six months prior to the current service start date.
 `AppSettings.current.service_start_date`.
-This can be set to either `5` or `6` anything else will default to `6`.
+This should be set to either `5` or `6` anything else will default to `6`.
 
 ### SSH access
 

--- a/app/models/form/eligibility_check.rb
+++ b/app/models/form/eligibility_check.rb
@@ -54,16 +54,11 @@ private
 
   # default to 6 and only allow 5 or 6. anything else results in 6.
   def months_limit
-    limit = ENV.fetch("CONTRACT_START_MONTHS_LIMIT", 6).to_i
+    limit = Rails.configuration.x.form_eligibility.contract_start_months_limit.to_i
     [5, 6].include?(limit) ? limit : 6
   end
 
   def months_limit_in_words
-    case months_limit
-    when 5
-      "five"
-    else
-      "six"
-    end
+    months_limit == 5 ? "five" : "six"
   end
 end

--- a/app/models/form/eligibility_check.rb
+++ b/app/models/form/eligibility_check.rb
@@ -31,7 +31,7 @@ class Form::EligibilityCheck
     in visa_type: "Other"
       "visa not accepted"
     in start_date: Date unless contract_start_date_eligible?(form.start_date)
-      "contract must start after the first monday of July of this year"
+      I18n.t("contract_must_start_within_months", count: months_limit_in_words)
     in date_of_entry: Date, start_date: Date unless date_of_entry_eligible?(form.date_of_entry, form.start_date)
       "cannot enter the UK more than 3 months before your contract start date"
     else
@@ -46,11 +46,24 @@ class Form::EligibilityCheck
   end
 
   def contract_start_date_eligible?(start_date)
-    current_year = Date.current.year
-    first_monday_in_july = Date.new(current_year, 7, 1)
-                             .beginning_of_month
-                             .next_occurring(:monday)
+    months_before_service_start = AppSettings.current.service_start_date.months_ago(months_limit).beginning_of_month
+    start_date >= months_before_service_start
+  end
 
-    start_date >= first_monday_in_july
+private
+
+  # default to 6 and only allow 5 or 6. anything else results in 6.
+  def months_limit
+    limit = ENV.fetch("CONTRACT_START_MONTHS_LIMIT", 6).to_i
+    [5, 6].include?(limit) ? limit : 6
+  end
+
+  def months_limit_in_words
+    case months_limit
+    when 5
+      "five"
+    else
+      "six"
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,5 +49,6 @@ module GetAnInternationalRelocationPayment
 
     config.x.govuk_notify.generic_email_template_id = ENV.fetch("GOVUK_NOTIFY_GENERIC_EMAIL_TEMPLATE_ID")
     config.x.events.filtered_attributes = YAML.load_file(Rails.root.join("config/events/filtered_attributes.yml"))
+    config.x.form_eligibility.contract_start_months_limit = 6
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,3 +61,4 @@ en:
               ho_missing_header_mappings: "config.header_mappings must be present"
               ho_missing_worksheet_name: "config.worksheet_name must be present"
               ho_invalid_worksheet_name: "config.worksheet_name not present in file"
+  contract_must_start_within_months: contract must start within the last %{count} months

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -63,8 +63,8 @@ FactoryBot.define do
           "Youth Mobility Scheme",
         ].sample
       end
-      start_date { Date.new(Date.current.year, 9, 1) }
-      date_of_entry { Date.new(Date.current.year, 9, 1) }
+      start_date { 1.month.ago }
+      date_of_entry { 1.month.ago }
       subject { "physics" }
     end
 
@@ -72,8 +72,8 @@ FactoryBot.define do
       state_funded_secondary_school { true }
       one_year { true }
       visa_type { "British National (Overseas) visa" }
-      start_date { Date.new(Date.current.year, 9, 1) }
-      date_of_entry { Date.new(Date.current.year, 9, 1) }
+      start_date { 1.month.ago }
+      date_of_entry { 1.month.ago }
       subject { "physics" }
       date_of_birth { rand(18..90).years.ago.to_date }
       email_address { Faker::Internet.email }

--- a/spec/models/form/eligibility_check_spec.rb
+++ b/spec/models/form/eligibility_check_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Form::EligibilityCheck do
                 start_date: Date.new(2023, 10, 31),
                 date_of_entry: Date.new(2023, 10, 31))
         end
-        let(:expected) { "contract must start within the last five months"}
+        let(:expected) { "contract must start within the last five months" }
 
         it { expect(check.failure_reason).to eq(expected) }
       end

--- a/spec/models/form/eligibility_check_spec.rb
+++ b/spec/models/form/eligibility_check_spec.rb
@@ -12,6 +12,110 @@ RSpec.describe Form::EligibilityCheck do
       it { expect(check.failure_reason).to be_nil }
     end
 
+    context "in the Jan/Feb 2024 window" do
+      before do
+        travel_to Time.zone.local(2024, 1, 2)
+        AppSettings.current.update!(
+          service_start_date: Time.zone.today,
+          service_end_date: 1.month.from_now.end_of_month,
+        )
+        travel_to Time.zone.local(2024, 2, 29)
+      end
+
+      let(:form) { build(:form, :eligible) }
+
+      context "when the contract start date is September 2023" do
+        let(:form) do
+          build(:form, :eligible,
+                start_date: Date.new(2023, 9, 2),
+                date_of_entry: Date.new(2023, 9, 2))
+        end
+
+        it { expect(check.failure_reason).to be_nil }
+      end
+
+      context "when the contract start date is Jan 2024" do
+        let(:form) do
+          build(:form, :eligible,
+                start_date: Date.new(2024, 1, 1),
+                date_of_entry: Date.new(2024, 1, 1))
+        end
+
+        it { expect(check.failure_reason).to be_nil }
+      end
+
+      context "when the contract start date is July 2023" do
+        let(:form) do
+          build(:form, :eligible,
+                start_date: Date.new(2023, 7, 1),
+                date_of_entry: Date.new(2023, 7, 1))
+        end
+
+        it { expect(check.failure_reason).to be_nil }
+      end
+
+      context "when the contract start date is June 2023" do
+        let(:form) do
+          build(:form, :eligible,
+                start_date: Date.new(2023, 6, 30),
+                date_of_entry: Date.new(2023, 6, 30))
+        end
+        let(:expected) { "contract must start within the last six months" }
+
+        it { expect(check.failure_reason).to eq(expected) }
+      end
+    end
+
+    context "in the Apr/May 2024 window" do
+      before do
+        travel_to Time.zone.local(2024, 4, 1)
+        AppSettings.current.update!(
+          service_start_date: Time.zone.today,
+          service_end_date: 1.month.from_now.end_of_month,
+        )
+        travel_to Time.zone.local(2024, 5, 31)
+        ENV["CONTRACT_START_MONTHS_LIMIT"] = "5"
+      end
+
+      after do
+        ENV.delete("CONTRACT_START_MONTHS_LIMIT")
+      end
+
+      let(:form) { build(:form, :eligible) }
+
+      context "when the contract start date is September 2023" do
+        let(:form) do
+          build(:form, :eligible,
+                start_date: Date.new(2023, 9, 30),
+                date_of_entry: Date.new(2023, 9, 30))
+        end
+        let(:expected) { "contract must start within the last five months" }
+
+        it { expect(check.failure_reason).to eq(expected) }
+      end
+
+      context "when the contract start date is October 2023" do
+        let(:form) do
+          build(:form, :eligible,
+                start_date: Date.new(2023, 10, 31),
+                date_of_entry: Date.new(2023, 10, 31))
+        end
+        let(:expected) { "contract must start within the last five months"}
+
+        it { expect(check.failure_reason).to eq(expected) }
+      end
+
+      context "when the contract start date is Jan 2024" do
+        let(:form) do
+          build(:form, :eligible,
+                start_date: Date.new(2024, 1, 1),
+                date_of_entry: Date.new(2024, 1, 1))
+        end
+
+        it { expect(check.failure_reason).to be_nil }
+      end
+    end
+
     context "when ineligible" do
       context "because of chosen application_route" do
         let(:form) { build(:form, application_route: "other") }
@@ -49,8 +153,8 @@ RSpec.describe Form::EligibilityCheck do
       end
 
       context "because of start date too early" do
-        let(:form) { build(:form, start_date: Date.new(Date.current.year, 6, 30)) }
-        let(:expected) { "contract must start after the first monday of July of this year" }
+        let(:form) { build(:form, start_date: 8.months.ago) }
+        let(:expected) { "contract must start within the last six months" }
 
         it { expect(check.failure_reason).to eq(expected) }
       end
@@ -59,8 +163,8 @@ RSpec.describe Form::EligibilityCheck do
         let(:form) do
           build(
             :form,
-            start_date: Date.new(Date.current.year, 8, 30),
-            date_of_entry: Date.new(Date.current.year, 5, 29),
+            start_date: 1.month.ago,
+            date_of_entry: 5.months.ago,
           )
         end
         let(:expected) { "cannot enter the UK more than 3 months before your contract start date" }

--- a/spec/models/form/eligibility_check_spec.rb
+++ b/spec/models/form/eligibility_check_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe Form::EligibilityCheck do
           service_end_date: 1.month.from_now.end_of_month,
         )
         travel_to Time.zone.local(2024, 5, 31)
-        ENV["CONTRACT_START_MONTHS_LIMIT"] = "5"
+        Rails.configuration.x.form_eligibility.contract_start_months_limit = 5
       end
 
       after do
-        ENV.delete("CONTRACT_START_MONTHS_LIMIT")
+        Rails.configuration.x.form_eligibility.contract_start_months_limit = 6
       end
 
       let(:form) { build(:form, :eligible) }

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
## Description
Upgrade the code for the eligibility check on the form for the contract start date, so that it works as expected in 2024.
Added the option to configure a 5 month window for the date as an alternative to the default of 6.  The custom rails configuration entry `config.x.form_eligibility.contract_start_months_limit` can be set to `5` to allow this.  If the entry is set to anything other than 5 or 6 it will default to 6 months.

## Trello Card Link

[Fix for contract start date](https://trello.com/c/hv4fBjnR/265-bug-fix-on-current-dates-in-application-form)