### PR TITLE
Bump govuk-frontend from 4.7.0 to 5.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "scenic"
 ###############
 # Used to build our forms and style them using govuk-frontend class names
 gem "govuk-components", "5.0.0"
-gem "govuk_design_system_formbuilder"
+gem "govuk_design_system_formbuilder", "5.0.0"
 gem "notifications-ruby-client"
 # UK postcode parsing and validation for Ruby
 gem "uk_postcode"

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "scenic"
 # GOVUK GEMS ##
 ###############
 # Used to build our forms and style them using govuk-frontend class names
-gem "govuk-components", "4.1.2"
+gem "govuk-components", "5.0.0"
 gem "govuk_design_system_formbuilder"
 gem "notifications-ruby-client"
 # UK postcode parsing and validation for Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,10 +206,10 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.24.4)
-    govuk-components (4.1.2)
+    govuk-components (5.0.0)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
-      view_component (>= 3.3, < 3.7)
+      view_component (>= 3.3, < 3.8)
     govuk_design_system_formbuilder (4.1.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
@@ -477,7 +477,7 @@ GEM
     uk_postcode (2.1.8)
     unicode-display_width (2.4.2)
     version_gem (1.1.3)
-    view_component (3.6.0)
+    view_component (3.7.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -520,7 +520,7 @@ DEPENDENCIES
   flipper-active_record
   flipper-ui
   foreman
-  govuk-components (= 4.1.2)
+  govuk-components (= 5.0.0)
   govuk_design_system_formbuilder
   httparty (~> 0.21)
   importmap-rails (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
       view_component (>= 3.3, < 3.8)
-    govuk_design_system_formbuilder (4.1.1)
+    govuk_design_system_formbuilder (5.0.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -521,7 +521,7 @@ DEPENDENCIES
   flipper-ui
   foreman
   govuk-components (= 5.0.0)
-  govuk_design_system_formbuilder
+  govuk_design_system_formbuilder (= 5.0.0)
   httparty (~> 0.21)
   importmap-rails (~> 1.2)
   invisible_captcha

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "govuk-frontend": "^4.7.0"
+    "govuk-frontend": "^5.0.0"
  },
   "license": "MIT"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-govuk-frontend@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.7.0.tgz#69950b6c2e69f435ffe9aa60d8dee232dac977de"
-  integrity sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==
+govuk-frontend@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.0.0.tgz#c08a4d1115fb31eb39b6d19979c627f816185dd7"
+  integrity sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g==


### PR DESCRIPTION
## Description

This PR updates (npm) govuk-frontend, (gem) govuk-components and (gem) govuk_design_system_formbuilder

## Closes PRs

#348, #350 and #353