### PR TITLE
Landing Page minor change

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-full">
     <p class="govuk-body">
       The international relocation payment (IRP) is a single payment of £10,000,
-      funded by the UK government which is available to eligible non-UK trainees and teachers of:
+      funded by the UK government, which is available to eligible non-UK trainees and teachers of:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>languages</li>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-l">Not ready to apply?</h2>
     <p class="govuk-body">
       If you have not started your job or course, you can
-      <%= govuk_link_to("express your interest in applying for the international relocation payment later in 2024.",
+      <%= govuk_link_to("express your interest in applying for the international relocation payment.",
                         "mailto:IRP.ExpressInterest@education.gov.uk") %>
     </p>
 


### PR DESCRIPTION
## Description
 - Remove the text `later in 2024` from the `express interest...` link content 
 - Add the comma back after `funded by the UK government`

## Trello Card Link

https://trello.com/c/7HIMxjYX/267-implement-new-landing-page-content
