### PR TITLE
Enable azure rbac deployment

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -73,7 +73,7 @@ runs:
           ${{ env.key_vault_app_secret_name }}
           ${{ env.key_vault_infra_secret_name }}
 
-    - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
       with:
         azure-credentials: ${{ inputs.azure-credentials }}
 

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -37,7 +37,7 @@ jobs:
     - name: K8 setup
       shell: bash
       run: |
-        az aks get-credentials -g s189p01-tsc-pd-rg -n s189p01-tsc-production-aks
+        make ci production get-cluster-credentials
         make install-konduit
 
     - name: Setup postgres client

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -58,7 +58,7 @@ jobs:
       #       ${{ env.key_vault_app_secret_name }}
       #       ${{ env.key_vault_infra_secret_name }}
 
-      - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
         if: env.TF_STATE_EXISTS == 'true'
         with:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ print-infra-secrets: read-tf-config install-fetch-config set-azure-account
 
 get-cluster-credentials: read-cluster-config set-azure-account ## make <config> get-cluster-credentials [ENVIRONMENT=<clusterX>]
 	az aks get-credentials --overwrite-existing -g ${AZURE_RESOURCE_PREFIX}-tsc-${CLUSTER_SHORT}-rg -n ${AZURE_RESOURCE_PREFIX}-tsc-${CLUSTER}-aks
+	kubelogin convert-kubeconfig -l $(if ${GITHUB_ACTIONS},spn,azurecli)
 
 console: get-cluster-credentials
 	$(if $(APP_NAME), $(eval export APP_ID=$(APP_NAME)) , $(eval export APP_ID=$(CONFIG_LONG)))

--- a/docs/aks-cheatsheet.md
+++ b/docs/aks-cheatsheet.md
@@ -53,11 +53,10 @@ Select account for az:
 $ az account set -s s189-teacher-services-cloud-test
 ```
 
-Get access credentials for a managed Kubernetes cluster (passing the
-resource group and the name):
+Get access credentials for a managed Kubernetes cluster (passing the app environment):
 
 ```
-$ az aks get-credentials -g s189t01-tsc-ts-rg -n s189t01-tsc-test-aks
+$ make qa get-cluster-credentials
 ```
 
 When you have multiple cluster credentials loaded, you can switch between clusters

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -34,6 +34,15 @@ provider "kubernetes" {
   client_certificate     = module.cluster_data.kubernetes_client_certificate
   client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+
+  dynamic "exec" {
+    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
+    content {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "kubelogin"
+      args        = module.cluster_data.kubelogin_args
+    }
+  }
 }
 
 provider "statuscake" {


### PR DESCRIPTION
## Description

Enable azure rbac on deployment (for when it is enabled in the cluster)

## Trello Card Link

https://trello.com/c/3m8PNLG6/937-enable-azure-rbac-deployment-on-all-services

Not to be deployed until terraform modules has been updated on Monday Jan 29th.

### Changes proposed in this pull request

Update Makefile, terraform and workflows to use rbac if configured for the cluster

### Guidance to review

make env terraform-plan
check review app deploys successfully
