### PR TITLE
Add set-kubelogin to database backup workflow

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -29,6 +29,10 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION }}
 
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION }}
+
     - name: Install kubectl
       uses: azure/setup-kubectl@v3
       with:


### PR DESCRIPTION
## Description

Add set-kubelogin to database backup workflow, as this is required after adding rbac authentication

## How to review

Run manually against branch. see https://github.com/DFE-Digital/get-a-teacher-relocation-payment/actions/runs/7724602277 

