### PR TITLE
[1654] Add Teacher payments contact group

### DIFF
--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -25,7 +25,7 @@
       "alert": {
         "website_url": [ "https://get-a-teacher-relocation-payment.education.gov.uk/healthcheck/all" ],
         "ssl_url": [ "https://get-a-teacher-relocation-payment.education.gov.uk" ],
-        "contact_group": [282453]
+        "contact_group": [195955, 282453]
       }
     }
 }


### PR DESCRIPTION
## Description
The Teacher payments team are now responsible for the service. Add their group to statuscake alerting.

## Trello Card Link
https://trello.com/c/Z6eliKhq
