### PR TITLE
Content (date) change for IRP

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -74,7 +74,7 @@
       Applications for the international relocation payment (IRP) are open from:
     </p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>2 April to 31 May 2024</li>
+      <li>2 April to 16 June 2024</li>
     </ul>
     <p class="govuk-body">
       If you have started your teaching job or salaried teacher training course, you should apply now. If you are eligible, you should receive the money by 30 September 2024.


### PR DESCRIPTION
## Description

Makes a content change to reflect the IRP programme dates.

Applications for the international relocation payment (IRP) are open from: 
2 April to 16 June ~31 May~ 2024

## Trello Card Link

https://dfedigital.atlassian.net/browse/CAPT-1627
