### PR TITLE
Remove additionaly copy from the ineligible_salaried_course page

### DIFF
--- a/app/views/pages/ineligible_salaried_course.html.erb
+++ b/app/views/pages/ineligible_salaried_course.html.erb
@@ -1,10 +1,3 @@
-<%= render layout: 'pages/shared/body' do %>
-  <p class="govuk-body">
-    If you are enrolled on a fee-paying teacher training course, and meet the eligibility requirements for trainees,
-    you do not need to apply to receive the international
-    payment. <%= govuk_link_to "Get an international relocation payment: criteria for trainee teachers", "https://getintoteaching.education.gov.uk/non-uk-teachers/fees-and-funding-for-non-uk-trainees#get-an-international-relocation-payment-irp-worth-10000", { target: "_blank" } %>
-    gives more information.
-  </p>
-<% end %>
+<%= render partial: 'pages/shared/body' %>
 
 <%= render partial: 'pages/shared/footer' %>

--- a/app/views/pages/shared/_body.html.erb
+++ b/app/views/pages/shared/_body.html.erb
@@ -4,6 +4,5 @@
       We’re sorry, but you are not currently eligible
       for the international relocation payment
     </h1>
-    <%= yield if block_given?%>
   </div>
 </div>

--- a/spec/features/trainee_route_completing_the_form_spec.rb
+++ b/spec/features/trainee_route_completing_the_form_spec.rb
@@ -31,7 +31,6 @@ describe "trainee route: completing the form" do
         and_i_complete_the_trainee_employment_conditions(choose: "No")
 
         expect(page).to have_text("We’re sorry")
-                          .and have_text("If you are enrolled on a fee-paying teacher training course")
       end
     end
   end


### PR DESCRIPTION
Removes the additionaly copy from the ineligible_salaried_course page

https://github.com/DFE-Digital/get-a-teacher-relocation-payment/assets/9936028/b8b68546-a6d0-49f8-b327-7e36e8ca0bb4

https://dfedigital.atlassian.net/browse/CAPT-1629
