### PR TITLE
Configure semantic logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "uk_postcode"
 gem "phonelib"
 ###############
 
+gem "amazing_print"
 gem "audited", "~> 5.4"
 gem "concurrent-ruby", require: "concurrent"
 gem "concurrent-ruby-ext"
@@ -41,6 +42,7 @@ gem "flipper-ui"
 gem "httparty", "~> 0.21"
 gem "invisible_captcha"
 gem "omniauth-azure-activedirectory-v2"
+gem "rails_semantic_logger"
 gem "rolify"
 gem "sentry-rails", "~> 5.17"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    amazing_print (1.6.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
@@ -353,6 +354,10 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails_semantic_logger (4.14.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.13)
     railties (7.1.2)
       actionpack (= 7.1.2)
       activesupport (= 7.1.2)
@@ -445,6 +450,8 @@ GEM
     scenic (1.7.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
+    semantic_logger (4.15.0)
+      concurrent-ruby (~> 1.0)
     sentry-rails (5.17.1)
       railties (>= 5.0)
       sentry-ruby (~> 5.17.1)
@@ -502,6 +509,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  amazing_print
   annotate
   audited (~> 5.4)
   binding_of_caller
@@ -540,6 +548,7 @@ DEPENDENCIES
   pry-byebug
   puma (>= 6.4.2, < 7)
   rails (~> 7.1)
+  rails_semantic_logger
   rolify
   rspec-rails
   rubocop-govuk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.6)
     minitest (5.22.3)
     msgpack (1.7.2)
     multi_xml (0.6.0)
@@ -274,7 +274,7 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.6.1)
-    nokogiri (1.16.3)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
@@ -321,7 +321,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
-    racc (1.7.3)
+    racc (1.8.0)
     rack (2.2.8.1)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
@@ -374,7 +374,8 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rolify (6.0.1)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -470,6 +471,7 @@ GEM
       hashie
       version_gem (~> 1.1, >= 1.1.1)
     stringio (3.1.0)
+    strscan (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -556,7 +558,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.2.2p53
+   ruby 3.2.3p157
 
 BUNDLED WITH
    2.4.21

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,5 +62,12 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
+  # Or :info
+  config.log_level = :debug
+  # Console colorised non-json output
+  config.log_format = :color
+  # Show file and line number (expensive: not for production)
+  config.semantic_logger.backtrace_level = :debug
+
   config.hosts << "itrp.local"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,13 +43,6 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("healthcheck") } } }
 
-  # Include generic and useful information about system operation, but avoid logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -61,21 +54,21 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
+  # Include generic and useful information about system operation, but avoid logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII).
+  config.log_level = :info
+
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = Logger::Formatter.new
+  # Set format for semantic logger, see config/initializers/semantic_logger.rb
+  config.log_format = :json
 
-  # Use a different logger for distributed setups.
-  # require "syslog/logger"
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
+  # Don't log to file
+  config.rails_semantic_logger.add_file_appender = false
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  # Don't log SQL
+  config.active_record.logger = nil
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,5 +55,12 @@ Rails.application.configure do
   # config/initializers/dartsass.rb
   config.dartsass.build_options << " --quiet-deps"
 
+  # Or :info
+  config.log_level = :debug
+  # Console colorised non-json output
+  config.log_format = :color
+  # Show file and line number (expensive: not for production)
+  config.semantic_logger.backtrace_level = :debug
+
   config.hosts << "www.example.com"
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,0 +1,11 @@
+Rails.application.configure do
+  config.semantic_logger.application = "" # This is added by logstash from its tags
+  config.log_tags = [:request_id]         # Prepend all log lines with the following tags
+end
+
+SemanticLogger.add_appender(
+  io: $stdout,
+  level: Rails.application.config.log_level,
+  formatter: Rails.application.config.log_format,
+)
+Rails.application.config.logger.info("Application logging to STDOUT")


### PR DESCRIPTION
Configures the app to format it's logs with `rails_semantic_logger` so
logit can ingest them.
https://technical-guidance.education.gov.uk/infrastructure/monitoring/logit/#ruby-on-rails

Assumes app is logging to standard out in production
Also bumps some gems for security audit