### PR TITLE
Update azurerm provider

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -57,11 +57,11 @@ runs:
         fi
 
     - name: Use Terraform ${{ env.TERRAFORM_VERSION }}
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ env.TERRAFORM_VERSION }}
 
-    - uses: azure/login@v1
+    - uses: azure/login@v2
       with:
         creds: ${{ inputs.azure-credentials }}
 

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -3,15 +3,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.57.0"
+      version = "3.104.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.20.0"
+      version = "2.30.0"
     }
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = "2.1.0"
+      version = "2.2.0"
     }
   }
   backend "azurerm" {

--- a/terraform/custom_domains/environment_domains/terraform.tf
+++ b/terraform/custom_domains/environment_domains/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.43.0"
+      version = "3.104.2"
     }
   }
   backend "azurerm" {

--- a/terraform/custom_domains/infrastructure/terraform.tf
+++ b/terraform/custom_domains/infrastructure/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.43.0"
+      version = "3.104.2"
     }
   }
   backend "azurerm" {


### PR DESCRIPTION
## Description

https://trello.com/c/ST9hu2Bq/1840-update-azurerm-provider-to-31042

Update terraform providers as azurerm is using a version of the preview api that will become eol

Also update github actions in the deploy action to latest versions

## Changes proposed in this pull request

azurerm 3.43.0/3.53.0 -> 3.104.2
statuscake 2.1.0 -> 2.2.0
kubernetes 2.20.0 -> 2.30.0

## Guidance to review

make env terraform-plan
make dns domains-infra-plan
make qa dns domains-plan

redis will show below. data_persistence_authentication_method was added in a later module, SAS is the default.

```
  # module.redis.azurerm_redis_cache.main[0] will be updated in-place
  ~ resource "azurerm_redis_cache" "main" {

      ~ redis_configuration {
          + data_persistence_authentication_method  = "SAS"
            # (11 unchanged attributes hidden)
        }

```
