### PR TITLE
2046-setup-redirect-from-get-a-teacher-relocation-payment

### DIFF
--- a/terraform/custom_domains/environment_domains/config/trp_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/trp_production.tfvars.json
@@ -12,7 +12,11 @@
       ],
       "environment_short": "pd",
       "origin_hostname": "teacher-relocation-payment-production.teacherservices.cloud",
-      "null_host_header": true,
+      "redirect_rules":[{
+          "from-domain": "apex",
+          "to-domain": "getintoteaching.education.gov.uk",
+          "to-path": "/non-uk-teachers/get-an-international-relocation-payment"
+        }],
       "cnames": {
       }
     }

--- a/terraform/custom_domains/environment_domains/main.tf
+++ b/terraform/custom_domains/environment_domains/main.tf
@@ -10,6 +10,7 @@ module "domains" {
   host_name             = each.value.origin_hostname
   null_host_header      = try(each.value.null_host_header, false)
   cached_paths          = try(each.value.cached_paths, [])
+  redirect_rules        = try(each.value.redirect_rules, [])
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.


### PR DESCRIPTION
## Description
[get-a-teacher-relocation-payment.education.gov.uk](http://get-a-teacher-relocation-payment.education.gov.uk/) needs to be decommission, but before that happens we want to redirect the old service url to another url.

Set up a redirect from domain get-a-teacher-relocation-payment.education.gov.uk for both http and https and if there is any path on the end ignore it and just redirect to https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment

## Trello Card Link

https://trello.com/c/zu452h7b/2046-setup-redirect-from-get-a-teacher-relocation-payment-to-https-getintoteachingeducationgovuk-non-uk-teachers-get-an-international

https://trello.com/c/
