### PR TITLE
Hard redirect offsite

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,10 @@ class ApplicationController < ActionController::Base
     return if request.path == destroy_user_session_path # skip this for log out page
     return if Gatekeeper.application_open?
 
-    redirect_to("https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment")
+    redirect_to(
+      "https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment",
+      allow_other_host: true,
+    )
   end
 
   def current_form

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
     return if request.path == destroy_user_session_path # skip this for log out page
     return if Gatekeeper.application_open?
 
-    redirect_to(closed_path)
+    redirect_to("https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment")
   end
 
   def current_form

--- a/spec/features/admin_console/settings_spec.rb
+++ b/spec/features/admin_console/settings_spec.rb
@@ -22,7 +22,7 @@ describe "Settings" do
   it "does allow access to non-admin if Service is closed" do
     given_the_service_is_closed
     visit root_path
-    then_i_should_see_the_service_closed_page
+    then_i_should_see_offsite_guidance_page
   end
 
 private
@@ -31,8 +31,8 @@ private
     AppSettings.current.update!(service_start_date: 2.days.from_now)
   end
 
-  def then_i_should_see_the_service_closed_page
-    expect(page).to have_current_path("/closed")
+  def then_i_should_see_offsite_guidance_page
+    expect(page.current_url).to eql("https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment")
   end
 
   def when_i_visit_the_settings_page

--- a/spec/features/open_close_spec.rb
+++ b/spec/features/open_close_spec.rb
@@ -34,14 +34,7 @@ describe "Open / Close service" do
     it "does not allow the user access to the landing page" do
       visit root_path
 
-      expect(page).to have_current_path("/closed")
-    end
-
-    it "allows the user access to the admin tool" do
-      given_i_am_signed_with_role(:admin)
-      visit applicants_path
-
-      expect(page).to have_text("Applications")
+      expect(page.current_url).to eql("https://getintoteaching.education.gov.uk/non-uk-teachers/get-an-international-relocation-payment")
     end
   end
 end


### PR DESCRIPTION
# Context

- https://dfedigital.atlassian.net/browse/CAPT-1819
- Hard redirect closed service to offsite guidance page
- Theres failing test I can't figure out, I wanted to pend but linter complains, so it has been deleted